### PR TITLE
Agregar DockerFile basico para para API notas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Imagen base oficial de Python
+FROM python:3.9-slim
+
+# Directorio de trabajo
+WORKDIR /app
+
+# Copiar dependencias e instalar
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copiar el codigo fuente
+COPY . .
+
+# Exponer puerto
+EXPOSE 8000
+
+# Correr la app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Este PR implementa el Dockerfile básico para contenerizar la aplicacion FastAPI de gestion de notas.  Cumpliendo con la issue #5 

Pasos para probar:

```bash
# Construir la imagen
docker build -t notes-api .

# Ejecutar el contenedor
docker run -p 8000:8000 -e USE_MEMORY_DB=true notes-api

# Verificar que funciona
curl http://localhost:8000/health