### PR TITLE
Docker compose con API y PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Imagen base oficial de Python
+FROM python:3.9-slim
+
+# Directorio de trabajo
+WORKDIR /app
+
+# Copiar dependencias e instalar
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copiar el codigo fuente
+COPY . .
+
+# Exponer puerto
+EXPOSE 8000
+
+# Correr la app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+      - DATABASE_URL=postgresql://user:password@db:5432/notes_db
+      - USE_MEMORY_DB=false
+    volumes:
+      - ./app:/app/app
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: notes_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Este PR implementa la configuracion de Docker Compose para orquestar la aplicación FastAPI junto con la base de datos PostgreSQL, permitiendo levantar todo el stack con un solo comando.

Para probar:

```bash
# Levantar todos los servicios
docker compose up --build

# En otra terminal, verificar la conexión
curl http://localhost:8000/health
# Esperado: {"status": "ok", "database": "postgresql"}

# Crear una nota
curl -X POST "http://localhost:8000/notes" \
  -H "Content-Type: application/json" \
  -d '{"title": "Primera nota", "content": "Sprint1"}'

# Listar notas
curl http://localhost:8000/notes

# Verificar persistencia
docker compose down
docker compose up -d
curl http://localhost:8000/notes  
# Los datos deben persistir

# Limpiar
docker compose down -v