### PR TITLE
Germain choquechambi/automatizacion evidencias

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    */tests/*

--- a/.evidence/ci-report.txt
+++ b/.evidence/ci-report.txt
@@ -1,0 +1,19 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
+rootdir: /home/germain/archivos/pc5Sprint2/PC5-Grupo4-Proyecto1-DesarrolloDeSoftware
+plugins: cov-7.0.0, anyio-4.12.0
+collected 7 items
+
+tests/test_main.py .......                                               [100%]
+
+================================ tests coverage ================================
+_______________ coverage: platform linux, python 3.12.3-final-0 ________________
+
+Name              Stmts   Miss  Cover   Missing
+-----------------------------------------------
+app/__init__.py       0      0   100%
+app/database.py      37      8    78%   15, 20-23, 53-54, 59
+app/main.py          75     20    73%   47, 58-67, 84-85, 103-114
+-----------------------------------------------
+TOTAL               112     28    75%
+============================== 7 passed in 31.45s ==============================

--- a/.evidence/trivy-report.json
+++ b/.evidence/trivy-report.json
@@ -1,0 +1,15354 @@
+{
+  "SchemaVersion": 2,
+  "ReportID": "019aff3e-f7c6-7958-a5c1-97b755c970d5",
+  "CreatedAt": "2025-12-08T18:35:08.102620067Z",
+  "ArtifactID": "sha256:275e20c8faf3e4fae16b7625d71bac0df38fa9c3a2dfcff7a661d59fb62be185",
+  "ArtifactName": "myapp:latest",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "Size": 368379904,
+    "OS": {
+      "Family": "debian",
+      "Name": "13.1"
+    },
+    "ImageID": "sha256:a01d97097ff1152d007c0cf047eb8b05b3151df7d3016e077ee0ef79ce14ca4d",
+    "DiffIDs": [
+      "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c",
+      "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93",
+      "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea",
+      "sha256:c8f6b54339a8b44071408bd33dd69a9dc7db2ed9cdbf7c533ba09efecda5f33f",
+      "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7",
+      "sha256:7239b935b46428be9b330dd6c692dbbab324ca55df499eeff4e10a65620a8b00",
+      "sha256:7be0512b93ec9bfe2155623f5441118762d6bc8bb038b79bf8c5bc10d05c5d38",
+      "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb",
+      "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa",
+      "sha256:9f6bdeb08355949397157f582d6d216e72b618e2ab517f06b08fbd015da3d27b"
+    ],
+    "RepoTags": [
+      "myapp:latest"
+    ],
+    "Reference": "myapp:latest",
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2025-12-08T12:47:43.012213618-05:00",
+      "history": [
+        {
+          "created": "2025-10-20T00:00:00Z",
+          "created_by": "# debian.sh --arch 'amd64' out/ 'trixie' '@1760918400'",
+          "comment": "debuerreotype 0.16"
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "ENV LANG=C.UTF-8",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "RUN /bin/sh -c set -eux; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tca-certificates \t\tnetbase \t\ttzdata \t; \tapt-get dist-clean # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "ENV GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "ENV PYTHON_VERSION=3.9.25",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-10-31T23:14:26Z",
+          "created_by": "ENV PYTHON_SHA256=00e07d7c0f2f0cc002432d1ee84d2a40dae404a99303e3f97701c10966c91834",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-10-31T23:17:22Z",
+          "created_by": "RUN /bin/sh -c set -eux; \t\tsavedAptMark=\"$(apt-mark showmanual)\"; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tdpkg-dev \t\tgcc \t\tgnupg \t\tlibbluetooth-dev \t\tlibbz2-dev \t\tlibc6-dev \t\tlibdb-dev \t\tlibffi-dev \t\tlibgdbm-dev \t\tliblzma-dev \t\tlibncursesw5-dev \t\tlibreadline-dev \t\tlibsqlite3-dev \t\tlibssl-dev \t\tmake \t\ttk-dev \t\tuuid-dev \t\twget \t\txz-utils \t\tzlib1g-dev \t; \t\twget -O python.tar.xz \"https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz\"; \techo \"$PYTHON_SHA256 *python.tar.xz\" | sha256sum -c -; \twget -O python.tar.xz.asc \"https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc\"; \tGNUPGHOME=\"$(mktemp -d)\"; export GNUPGHOME; \tgpg --batch --keyserver hkps://keys.openpgp.org --recv-keys \"$GPG_KEY\"; \tgpg --batch --verify python.tar.xz.asc python.tar.xz; \tgpgconf --kill all; \trm -rf \"$GNUPGHOME\" python.tar.xz.asc; \tmkdir -p /usr/src/python; \ttar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \trm python.tar.xz; \t\tcd /usr/src/python; \tgnuArch=\"$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)\"; \t./configure \t\t--build=\"$gnuArch\" \t\t--enable-loadable-sqlite-extensions \t\t--enable-optimizations \t\t--enable-option-checking=fatal \t\t--enable-shared \t\t--with-ensurepip \t; \tnproc=\"$(nproc)\"; \tEXTRA_CFLAGS=\"$(dpkg-buildflags --get CFLAGS)\"; \tLDFLAGS=\"$(dpkg-buildflags --get LDFLAGS)\"; \tLDFLAGS=\"${LDFLAGS:--Wl},--strip-all\"; \tmake -j \"$nproc\" \t\t\"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}\" \t\t\"LDFLAGS=${LDFLAGS:-}\" \t; \trm python; \tmake -j \"$nproc\" \t\t\"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}\" \t\t\"LDFLAGS=${LDFLAGS:--Wl},-rpath='\\$\\$ORIGIN/../lib'\" \t\tpython \t; \tmake install; \t\tcd /; \trm -rf /usr/src/python; \t\tfind /usr/local -depth \t\t\\( \t\t\t\\( -type d -a \\( -name test -o -name tests -o -name idle_test \\) \\) \t\t\t-o \\( -type f -a \\( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \\) \\) \t\t\\) -exec rm -rf '{}' + \t; \t\tldconfig; \t\tapt-mark auto '.*' \u003e /dev/null; \tapt-mark manual $savedAptMark; \tfind /usr/local -type f -executable -not \\( -name '*tkinter*' \\) -exec ldd '{}' ';' \t\t| awk '/=\u003e/ { so = $(NF-1); if (index(so, \"/usr/local/\") == 1) { next }; gsub(\"^/(usr/)?\", \"\", so); printf \"*%s\\n\", so }' \t\t| sort -u \t\t| xargs -rt dpkg-query --search \t\t| awk 'sub(\":$\", \"\", $1) { print $1 }' \t\t| sort -u \t\t| xargs -r apt-mark manual \t; \tapt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \tapt-get dist-clean; \t\texport PYTHONDONTWRITEBYTECODE=1; \tpython3 --version; \t\tpip3 install \t\t--disable-pip-version-check \t\t--no-cache-dir \t\t--no-compile \t\t'setuptools==79.0.1' \t\t'wheel\u003c0.46' \t; \tpip3 --version # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-10-31T23:17:23Z",
+          "created_by": "RUN /bin/sh -c set -eux; \tfor src in idle3 pip3 pydoc3 python3 python3-config; do \t\tdst=\"$(echo \"$src\" | tr -d 3)\"; \t\t[ -s \"/usr/local/bin/$src\" ]; \t\t[ ! -e \"/usr/local/bin/$dst\" ]; \t\tln -svT \"$src\" \"/usr/local/bin/$dst\"; \tdone # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-10-31T23:17:23Z",
+          "created_by": "CMD [\"python3\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-12-08T17:47:22Z",
+          "created_by": "RUN /bin/sh -c apt-get update \u0026\u0026 apt-get install -y curl \u0026\u0026 rm -rf /var/lib/apt/lists/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:22Z",
+          "created_by": "WORKDIR /app",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:22Z",
+          "created_by": "COPY requirements.txt . # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:41Z",
+          "created_by": "RUN /bin/sh -c pip install --no-cache-dir -r requirements.txt # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:42Z",
+          "created_by": "COPY . . # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:43Z",
+          "created_by": "RUN /bin/sh -c useradd -m appuser # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2025-12-08T17:47:43Z",
+          "created_by": "USER appuser",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-12-08T17:47:43Z",
+          "created_by": "EXPOSE [8000/tcp]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-12-08T17:47:43Z",
+          "created_by": "HEALTHCHECK \u0026{[\"CMD-SHELL\" \"curl -f http://localhost:8000/health || exit 1\"] \"30s\" \"30s\" \"5s\" \"0s\" '\\x03'}",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2025-12-08T17:47:43Z",
+          "created_by": "CMD [\"uvicorn\" \"app.main:app\" \"--host\" \"0.0.0.0\" \"--port\" \"8000\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c",
+          "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93",
+          "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea",
+          "sha256:c8f6b54339a8b44071408bd33dd69a9dc7db2ed9cdbf7c533ba09efecda5f33f",
+          "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7",
+          "sha256:7239b935b46428be9b330dd6c692dbbab324ca55df499eeff4e10a65620a8b00",
+          "sha256:7be0512b93ec9bfe2155623f5441118762d6bc8bb038b79bf8c5bc10d05c5d38",
+          "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb",
+          "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa",
+          "sha256:9f6bdeb08355949397157f582d6d216e72b618e2ab517f06b08fbd015da3d27b"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "uvicorn",
+          "app.main:app",
+          "--host",
+          "0.0.0.0",
+          "--port",
+          "8000"
+        ],
+        "Healthcheck": {
+          "Test": [
+            "CMD-SHELL",
+            "curl -f http://localhost:8000/health || exit 1"
+          ],
+          "Interval": 30000000000,
+          "Timeout": 30000000000,
+          "StartPeriod": 5000000000,
+          "Retries": 3
+        },
+        "Env": [
+          "PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "LANG=C.UTF-8",
+          "GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568",
+          "PYTHON_VERSION=3.9.25",
+          "PYTHON_SHA256=00e07d7c0f2f0cc002432d1ee84d2a40dae404a99303e3f97701c10966c91834"
+        ],
+        "User": "appuser",
+        "WorkingDir": "/app",
+        "ExposedPorts": {
+          "8000/tcp": {}
+        },
+        "ArgsEscaped": true
+      }
+    },
+    "Layers": [
+      {
+        "Size": 81039360,
+        "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+      },
+      {
+        "Size": 4122624,
+        "DiffID": "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93"
+      },
+      {
+        "Size": 41286144,
+        "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+      },
+      {
+        "Size": 5120,
+        "DiffID": "sha256:c8f6b54339a8b44071408bd33dd69a9dc7db2ed9cdbf7c533ba09efecda5f33f"
+      },
+      {
+        "Size": 16475648,
+        "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+      },
+      {
+        "Size": 1536,
+        "DiffID": "sha256:7239b935b46428be9b330dd6c692dbbab324ca55df499eeff4e10a65620a8b00"
+      },
+      {
+        "Size": 2560,
+        "DiffID": "sha256:7be0512b93ec9bfe2155623f5441118762d6bc8bb038b79bf8c5bc10d05c5d38"
+      },
+      {
+        "Size": 105308160,
+        "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+      },
+      {
+        "Size": 120116736,
+        "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+      },
+      {
+        "Size": 22016,
+        "DiffID": "sha256:9f6bdeb08355949397157f582d6d216e72b618e2ab517f06b08fbd015da3d27b"
+      }
+    ]
+  },
+  "Results": [
+    {
+      "Target": "myapp:latest (debian 13.1)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Packages": [
+        {
+          "ID": "adduser@3.152",
+          "Name": "adduser",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/adduser@3.152?arch=all\u0026distro=debian-13.1",
+            "UID": "a43cd8c736fb1210"
+          },
+          "Version": "3.152",
+          "Arch": "all",
+          "SrcName": "adduser",
+          "SrcVersion": "3.152",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian Adduser Developers \u003cadduser@packages.debian.org\u003e",
+          "DependsOn": [
+            "passwd@1:4.17.4-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/sbin/adduser",
+            "/usr/sbin/deluser",
+            "/usr/share/doc/adduser/NEWS.Debian.gz",
+            "/usr/share/doc/adduser/README.gz",
+            "/usr/share/doc/adduser/TODO",
+            "/usr/share/doc/adduser/changelog.gz",
+            "/usr/share/doc/adduser/copyright",
+            "/usr/share/doc/adduser/examples/INSTALL",
+            "/usr/share/doc/adduser/examples/README",
+            "/usr/share/doc/adduser/examples/adduser.conf",
+            "/usr/share/doc/adduser/examples/adduser.local",
+            "/usr/share/doc/adduser/examples/adduser.local.conf",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/bash.bashrc",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/profile",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/skel.other/index.html",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/skel/dot.bash_logout",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/skel/dot.bash_profile",
+            "/usr/share/doc/adduser/examples/adduser.local.conf.examples/skel/dot.bashrc",
+            "/usr/share/doc/adduser/examples/deluser.conf",
+            "/usr/share/man/da/man5/deluser.conf.5.gz",
+            "/usr/share/man/de/man5/adduser.conf.5.gz",
+            "/usr/share/man/de/man5/deluser.conf.5.gz",
+            "/usr/share/man/de/man8/adduser.8.gz",
+            "/usr/share/man/de/man8/adduser.local.8.gz",
+            "/usr/share/man/de/man8/deluser.8.gz",
+            "/usr/share/man/es/man5/deluser.conf.5.gz",
+            "/usr/share/man/fr/man5/adduser.conf.5.gz",
+            "/usr/share/man/fr/man5/deluser.conf.5.gz",
+            "/usr/share/man/fr/man8/adduser.8.gz",
+            "/usr/share/man/fr/man8/deluser.8.gz",
+            "/usr/share/man/it/man5/deluser.conf.5.gz",
+            "/usr/share/man/man5/adduser.conf.5.gz",
+            "/usr/share/man/man5/deluser.conf.5.gz",
+            "/usr/share/man/man8/adduser.8.gz",
+            "/usr/share/man/man8/adduser.local.8.gz",
+            "/usr/share/man/man8/deluser.8.gz",
+            "/usr/share/man/nl/man5/adduser.conf.5.gz",
+            "/usr/share/man/nl/man5/deluser.conf.5.gz",
+            "/usr/share/man/nl/man8/adduser.8.gz",
+            "/usr/share/man/nl/man8/adduser.local.8.gz",
+            "/usr/share/man/nl/man8/deluser.8.gz",
+            "/usr/share/man/pl/man5/deluser.conf.5.gz",
+            "/usr/share/man/pt/man5/adduser.conf.5.gz",
+            "/usr/share/man/pt/man5/deluser.conf.5.gz",
+            "/usr/share/man/pt/man8/adduser.8.gz",
+            "/usr/share/man/pt/man8/adduser.local.8.gz",
+            "/usr/share/man/pt/man8/deluser.8.gz",
+            "/usr/share/man/ro/man5/adduser.conf.5.gz",
+            "/usr/share/man/ro/man5/deluser.conf.5.gz",
+            "/usr/share/man/ro/man8/adduser.8.gz",
+            "/usr/share/man/ro/man8/adduser.local.8.gz",
+            "/usr/share/man/ro/man8/deluser.8.gz",
+            "/usr/share/man/ru/man5/deluser.conf.5.gz",
+            "/usr/share/man/sv/man5/deluser.conf.5.gz",
+            "/usr/share/perl5/Debian/AdduserCommon.pm",
+            "/usr/share/perl5/Debian/AdduserLogging.pm",
+            "/usr/share/perl5/Debian/AdduserRetvalues.pm"
+          ]
+        },
+        {
+          "ID": "apt@3.0.3",
+          "Name": "apt",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/apt@3.0.3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "26cbc052ac267c2"
+          },
+          "Version": "3.0.3",
+          "Arch": "amd64",
+          "SrcName": "apt",
+          "SrcVersion": "3.0.3",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "curl",
+            "BSD-3-Clause",
+            "MIT",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "APT Development Team \u003cdeity@lists.debian.org\u003e",
+          "DependsOn": [
+            "adduser@3.152",
+            "base-passwd@3.6.7",
+            "debian-archive-keyring@2025.1",
+            "libapt-pkg7.0@3.0.3",
+            "libc6@2.41-12",
+            "libgcc-s1@14.2.0-19",
+            "libseccomp2@2.6.0-2",
+            "libssl3t64@3.5.1-1+deb13u1",
+            "libstdc++6@14.2.0-19",
+            "libsystemd0@257.8-1~deb13u2",
+            "sqv@1.3.0-3"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/apt",
+            "/usr/bin/apt-cache",
+            "/usr/bin/apt-cdrom",
+            "/usr/bin/apt-config",
+            "/usr/bin/apt-get",
+            "/usr/bin/apt-mark",
+            "/usr/lib/apt/apt-extracttemplates",
+            "/usr/lib/apt/apt-helper",
+            "/usr/lib/apt/apt.systemd.daily",
+            "/usr/lib/apt/methods/cdrom",
+            "/usr/lib/apt/methods/copy",
+            "/usr/lib/apt/methods/file",
+            "/usr/lib/apt/methods/gpgv",
+            "/usr/lib/apt/methods/http",
+            "/usr/lib/apt/methods/mirror",
+            "/usr/lib/apt/methods/rred",
+            "/usr/lib/apt/methods/sqv",
+            "/usr/lib/apt/methods/store",
+            "/usr/lib/apt/solvers/dump",
+            "/usr/lib/dpkg/methods/apt/desc.apt",
+            "/usr/lib/dpkg/methods/apt/install",
+            "/usr/lib/dpkg/methods/apt/names",
+            "/usr/lib/dpkg/methods/apt/setup",
+            "/usr/lib/dpkg/methods/apt/update",
+            "/usr/lib/systemd/system/apt-daily-upgrade.service",
+            "/usr/lib/systemd/system/apt-daily-upgrade.timer",
+            "/usr/lib/systemd/system/apt-daily.service",
+            "/usr/lib/systemd/system/apt-daily.timer",
+            "/usr/lib/x86_64-linux-gnu/libapt-private.so.0.0.0",
+            "/usr/share/apt/default-sequoia.config",
+            "/usr/share/bash-completion/completions/apt",
+            "/usr/share/bug/apt/script",
+            "/usr/share/doc/apt/NEWS.Debian.gz",
+            "/usr/share/doc/apt/README.md.gz",
+            "/usr/share/doc/apt/changelog.gz",
+            "/usr/share/doc/apt/copyright",
+            "/usr/share/doc/apt/examples/apt.conf",
+            "/usr/share/doc/apt/examples/configure-index",
+            "/usr/share/doc/apt/examples/debian.sources",
+            "/usr/share/doc/apt/examples/preferences",
+            "/usr/share/lintian/overrides/apt",
+            "/usr/share/locale/ar/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ast/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/bs/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/cy/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/da/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/de/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/dz/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/el/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/es/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/it/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/km/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ku/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/mr/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ne/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/nn/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/th/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/tl/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/apt.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/apt.mo",
+            "/usr/share/man/de/man1/apt-transport-http.1.gz",
+            "/usr/share/man/de/man1/apt-transport-https.1.gz",
+            "/usr/share/man/de/man1/apt-transport-mirror.1.gz",
+            "/usr/share/man/de/man5/apt.conf.5.gz",
+            "/usr/share/man/de/man5/apt_auth.conf.5.gz",
+            "/usr/share/man/de/man5/apt_preferences.5.gz",
+            "/usr/share/man/de/man5/sources.list.5.gz",
+            "/usr/share/man/de/man7/apt-patterns.7.gz",
+            "/usr/share/man/de/man8/apt-cache.8.gz",
+            "/usr/share/man/de/man8/apt-cdrom.8.gz",
+            "/usr/share/man/de/man8/apt-config.8.gz",
+            "/usr/share/man/de/man8/apt-get.8.gz",
+            "/usr/share/man/de/man8/apt-mark.8.gz",
+            "/usr/share/man/de/man8/apt-secure.8.gz",
+            "/usr/share/man/de/man8/apt.8.gz",
+            "/usr/share/man/es/man5/apt_preferences.5.gz",
+            "/usr/share/man/es/man8/apt-cache.8.gz",
+            "/usr/share/man/es/man8/apt-cdrom.8.gz",
+            "/usr/share/man/es/man8/apt-config.8.gz",
+            "/usr/share/man/fr/man1/apt-transport-http.1.gz",
+            "/usr/share/man/fr/man1/apt-transport-https.1.gz",
+            "/usr/share/man/fr/man1/apt-transport-mirror.1.gz",
+            "/usr/share/man/fr/man5/apt.conf.5.gz",
+            "/usr/share/man/fr/man5/apt_auth.conf.5.gz",
+            "/usr/share/man/fr/man5/apt_preferences.5.gz",
+            "/usr/share/man/fr/man5/sources.list.5.gz",
+            "/usr/share/man/fr/man7/apt-patterns.7.gz",
+            "/usr/share/man/fr/man8/apt-cache.8.gz",
+            "/usr/share/man/fr/man8/apt-cdrom.8.gz",
+            "/usr/share/man/fr/man8/apt-config.8.gz",
+            "/usr/share/man/fr/man8/apt-get.8.gz",
+            "/usr/share/man/fr/man8/apt-mark.8.gz",
+            "/usr/share/man/fr/man8/apt-secure.8.gz",
+            "/usr/share/man/fr/man8/apt.8.gz",
+            "/usr/share/man/it/man5/apt.conf.5.gz",
+            "/usr/share/man/it/man5/apt_preferences.5.gz",
+            "/usr/share/man/it/man8/apt-cache.8.gz",
+            "/usr/share/man/it/man8/apt-cdrom.8.gz",
+            "/usr/share/man/it/man8/apt-config.8.gz",
+            "/usr/share/man/it/man8/apt-mark.8.gz",
+            "/usr/share/man/it/man8/apt.8.gz",
+            "/usr/share/man/ja/man5/apt.conf.5.gz",
+            "/usr/share/man/ja/man5/apt_preferences.5.gz",
+            "/usr/share/man/ja/man8/apt-cache.8.gz",
+            "/usr/share/man/ja/man8/apt-cdrom.8.gz",
+            "/usr/share/man/ja/man8/apt-config.8.gz",
+            "/usr/share/man/ja/man8/apt-mark.8.gz",
+            "/usr/share/man/ja/man8/apt.8.gz",
+            "/usr/share/man/man1/apt-transport-http.1.gz",
+            "/usr/share/man/man1/apt-transport-https.1.gz",
+            "/usr/share/man/man1/apt-transport-mirror.1.gz",
+            "/usr/share/man/man5/apt.conf.5.gz",
+            "/usr/share/man/man5/apt_auth.conf.5.gz",
+            "/usr/share/man/man5/apt_preferences.5.gz",
+            "/usr/share/man/man5/sources.list.5.gz",
+            "/usr/share/man/man7/apt-patterns.7.gz",
+            "/usr/share/man/man8/apt-cache.8.gz",
+            "/usr/share/man/man8/apt-cdrom.8.gz",
+            "/usr/share/man/man8/apt-config.8.gz",
+            "/usr/share/man/man8/apt-get.8.gz",
+            "/usr/share/man/man8/apt-mark.8.gz",
+            "/usr/share/man/man8/apt-secure.8.gz",
+            "/usr/share/man/man8/apt.8.gz",
+            "/usr/share/man/nl/man1/apt-transport-http.1.gz",
+            "/usr/share/man/nl/man1/apt-transport-https.1.gz",
+            "/usr/share/man/nl/man1/apt-transport-mirror.1.gz",
+            "/usr/share/man/nl/man5/apt.conf.5.gz",
+            "/usr/share/man/nl/man5/apt_auth.conf.5.gz",
+            "/usr/share/man/nl/man5/apt_preferences.5.gz",
+            "/usr/share/man/nl/man5/sources.list.5.gz",
+            "/usr/share/man/nl/man7/apt-patterns.7.gz",
+            "/usr/share/man/nl/man8/apt-cache.8.gz",
+            "/usr/share/man/nl/man8/apt-cdrom.8.gz",
+            "/usr/share/man/nl/man8/apt-config.8.gz",
+            "/usr/share/man/nl/man8/apt-get.8.gz",
+            "/usr/share/man/nl/man8/apt-mark.8.gz",
+            "/usr/share/man/nl/man8/apt-secure.8.gz",
+            "/usr/share/man/nl/man8/apt.8.gz",
+            "/usr/share/man/pl/man5/apt_preferences.5.gz",
+            "/usr/share/man/pl/man8/apt-cache.8.gz",
+            "/usr/share/man/pl/man8/apt-cdrom.8.gz",
+            "/usr/share/man/pl/man8/apt-config.8.gz",
+            "/usr/share/man/pt/man1/apt-transport-http.1.gz",
+            "/usr/share/man/pt/man1/apt-transport-https.1.gz",
+            "/usr/share/man/pt/man1/apt-transport-mirror.1.gz",
+            "/usr/share/man/pt/man5/apt.conf.5.gz",
+            "/usr/share/man/pt/man5/apt_auth.conf.5.gz",
+            "/usr/share/man/pt/man5/apt_preferences.5.gz",
+            "/usr/share/man/pt/man5/sources.list.5.gz",
+            "/usr/share/man/pt/man7/apt-patterns.7.gz",
+            "/usr/share/man/pt/man8/apt-cache.8.gz",
+            "/usr/share/man/pt/man8/apt-cdrom.8.gz",
+            "/usr/share/man/pt/man8/apt-config.8.gz",
+            "/usr/share/man/pt/man8/apt-get.8.gz",
+            "/usr/share/man/pt/man8/apt-mark.8.gz",
+            "/usr/share/man/pt/man8/apt-secure.8.gz",
+            "/usr/share/man/pt/man8/apt.8.gz"
+          ]
+        },
+        {
+          "ID": "base-files@13.8+deb13u1",
+          "Name": "base-files",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/base-files@13.8%2Bdeb13u1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "f2c993d1e1f97238"
+          },
+          "Version": "13.8+deb13u1",
+          "Arch": "amd64",
+          "SrcName": "base-files",
+          "SrcVersion": "13.8+deb13u1",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "verbatim"
+          ],
+          "Maintainer": "Santiago Vila \u003csanvila@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/os-release",
+            "/usr/share/base-files/dot.bashrc",
+            "/usr/share/base-files/dot.profile",
+            "/usr/share/base-files/dot.profile.md5sums",
+            "/usr/share/base-files/info.dir",
+            "/usr/share/base-files/motd",
+            "/usr/share/base-files/profile",
+            "/usr/share/base-files/profile.md5sums",
+            "/usr/share/base-files/staff-group-for-usr-local",
+            "/usr/share/common-licenses/Apache-2.0",
+            "/usr/share/common-licenses/Artistic",
+            "/usr/share/common-licenses/BSD",
+            "/usr/share/common-licenses/CC0-1.0",
+            "/usr/share/common-licenses/GFDL-1.2",
+            "/usr/share/common-licenses/GFDL-1.3",
+            "/usr/share/common-licenses/GPL-1",
+            "/usr/share/common-licenses/GPL-2",
+            "/usr/share/common-licenses/GPL-3",
+            "/usr/share/common-licenses/LGPL-2",
+            "/usr/share/common-licenses/LGPL-2.1",
+            "/usr/share/common-licenses/LGPL-3",
+            "/usr/share/common-licenses/MPL-1.1",
+            "/usr/share/common-licenses/MPL-2.0",
+            "/usr/share/doc/base-files/NEWS.Debian.gz",
+            "/usr/share/doc/base-files/README",
+            "/usr/share/doc/base-files/README.FHS",
+            "/usr/share/doc/base-files/changelog.gz",
+            "/usr/share/doc/base-files/copyright",
+            "/usr/share/lintian/overrides/base-files"
+          ]
+        },
+        {
+          "ID": "base-passwd@3.6.7",
+          "Name": "base-passwd",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/base-passwd@3.6.7?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e32fda680625d96d"
+          },
+          "Version": "3.6.7",
+          "Arch": "amd64",
+          "SrcName": "base-passwd",
+          "SrcVersion": "3.6.7",
+          "Licenses": [
+            "GPL-2.0-only",
+            "public-domain"
+          ],
+          "Maintainer": "Shadow package maintainers \u003cpkg-shadow-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libdebconfclient0@0.280",
+            "libselinux1@3.8.1-1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/sbin/update-passwd",
+            "/usr/share/base-passwd/group.master",
+            "/usr/share/base-passwd/passwd.master",
+            "/usr/share/doc-base/base-passwd.users-and-groups",
+            "/usr/share/doc/base-passwd/README",
+            "/usr/share/doc/base-passwd/changelog.gz",
+            "/usr/share/doc/base-passwd/copyright",
+            "/usr/share/doc/base-passwd/users-and-groups.html",
+            "/usr/share/doc/base-passwd/users-and-groups.txt.gz",
+            "/usr/share/lintian/overrides/base-passwd",
+            "/usr/share/man/de/man8/update-passwd.8.gz",
+            "/usr/share/man/es/man8/update-passwd.8.gz",
+            "/usr/share/man/fr/man8/update-passwd.8.gz",
+            "/usr/share/man/ja/man8/update-passwd.8.gz",
+            "/usr/share/man/man8/update-passwd.8.gz",
+            "/usr/share/man/pl/man8/update-passwd.8.gz",
+            "/usr/share/man/ro/man8/update-passwd.8.gz",
+            "/usr/share/man/ru/man8/update-passwd.8.gz"
+          ]
+        },
+        {
+          "ID": "bash@5.2.37-2+b5",
+          "Name": "bash",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/bash@5.2.37-2%2Bb5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "235aa9088a703d3c"
+          },
+          "Version": "5.2.37",
+          "Release": "2+b5",
+          "Arch": "amd64",
+          "SrcName": "bash",
+          "SrcVersion": "5.2.37",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GFDL-1.3-no-invariants-only",
+            "GFDL-1.3-only",
+            "Latex2e",
+            "BSD-4-Clause-UC",
+            "MIT",
+            "permissive"
+          ],
+          "Maintainer": "Matthias Klose \u003cdoko@debian.org\u003e",
+          "DependsOn": [
+            "base-files@13.8+deb13u1",
+            "debianutils@5.23.2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/bash",
+            "/usr/bin/bashbug",
+            "/usr/bin/clear_console",
+            "/usr/share/debianutils/shells.d/bash",
+            "/usr/share/doc/bash/CHANGES.gz",
+            "/usr/share/doc/bash/COMPAT.gz",
+            "/usr/share/doc/bash/INTRO.gz",
+            "/usr/share/doc/bash/NEWS.gz",
+            "/usr/share/doc/bash/POSIX.gz",
+            "/usr/share/doc/bash/RBASH",
+            "/usr/share/doc/bash/README.Debian.gz",
+            "/usr/share/doc/bash/README.abs-guide",
+            "/usr/share/doc/bash/README.commands.gz",
+            "/usr/share/doc/bash/README.gz",
+            "/usr/share/doc/bash/changelog.Debian.amd64.gz",
+            "/usr/share/doc/bash/changelog.Debian.gz",
+            "/usr/share/doc/bash/changelog.gz",
+            "/usr/share/doc/bash/copyright",
+            "/usr/share/doc/bash/inputrc.arrows",
+            "/usr/share/lintian/overrides/bash",
+            "/usr/share/locale/af/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/da/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/de/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/el/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/en@boldquot/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/en@quot/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/es/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/et/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/id/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/it/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/bash.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/bash.mo",
+            "/usr/share/man/man1/bash.1.gz",
+            "/usr/share/man/man1/bashbug.1.gz",
+            "/usr/share/man/man1/clear_console.1.gz",
+            "/usr/share/man/man1/rbash.1.gz",
+            "/usr/share/man/man7/bash-builtins.7.gz",
+            "/usr/share/menu/bash"
+          ]
+        },
+        {
+          "ID": "bash-completion@1:2.16.0-7",
+          "Name": "bash-completion",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/bash-completion@2.16.0-7?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "6e03bae277e89d0c"
+          },
+          "Version": "2.16.0",
+          "Release": "7",
+          "Epoch": 1,
+          "Arch": "all",
+          "SrcName": "bash-completion",
+          "SrcVersion": "2.16.0",
+          "SrcRelease": "7",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Gabriel F. T. Gomes \u003cgabriel@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/bin/dh_bash-completion",
+            "/usr/share/bash-completion/bash_completion",
+            "/usr/share/bash-completion/completions/2to3",
+            "/usr/share/bash-completion/completions/7z",
+            "/usr/share/bash-completion/completions/_adb",
+            "/usr/share/bash-completion/completions/_argc",
+            "/usr/share/bash-completion/completions/_cal",
+            "/usr/share/bash-completion/completions/_cargo",
+            "/usr/share/bash-completion/completions/_chfn",
+            "/usr/share/bash-completion/completions/_chsh",
+            "/usr/share/bash-completion/completions/_coder",
+            "/usr/share/bash-completion/completions/_delta",
+            "/usr/share/bash-completion/completions/_dmesg",
+            "/usr/share/bash-completion/completions/_eject",
+            "/usr/share/bash-completion/completions/_flamegraph",
+            "/usr/share/bash-completion/completions/_gaiacli",
+            "/usr/share/bash-completion/completions/_gh",
+            "/usr/share/bash-completion/completions/_golangci-lint",
+            "/usr/share/bash-completion/completions/_gsctl",
+            "/usr/share/bash-completion/completions/_hexdump",
+            "/usr/share/bash-completion/completions/_hwclock",
+            "/usr/share/bash-completion/completions/_insmod",
+            "/usr/share/bash-completion/completions/_ionice",
+            "/usr/share/bash-completion/completions/_jj",
+            "/usr/share/bash-completion/completions/_jungle",
+            "/usr/share/bash-completion/completions/_keyring",
+            "/usr/share/bash-completion/completions/_kontena",
+            "/usr/share/bash-completion/completions/_look",
+            "/usr/share/bash-completion/completions/_mdbook",
+            "/usr/share/bash-completion/completions/_mock",
+            "/usr/share/bash-completion/completions/_modinfo",
+            "/usr/share/bash-completion/completions/_modprobe",
+            "/usr/share/bash-completion/completions/_modules",
+            "/usr/share/bash-completion/completions/_mount",
+            "/usr/share/bash-completion/completions/_mount.linux",
+            "/usr/share/bash-completion/completions/_mtr",
+            "/usr/share/bash-completion/completions/_newgrp",
+            "/usr/share/bash-completion/completions/_nmcli",
+            "/usr/share/bash-completion/completions/_nox",
+            "/usr/share/bash-completion/completions/_nvm",
+            "/usr/share/bash-completion/completions/_pip",
+            "/usr/share/bash-completion/completions/_pipenv",
+            "/usr/share/bash-completion/completions/_renice",
+            "/usr/share/bash-completion/completions/_repomanage",
+            "/usr/share/bash-completion/completions/_reptyr",
+            "/usr/share/bash-completion/completions/_rfkill",
+            "/usr/share/bash-completion/completions/_rg",
+            "/usr/share/bash-completion/completions/_rmmod",
+            "/usr/share/bash-completion/completions/_rtcwake",
+            "/usr/share/bash-completion/completions/_ruff",
+            "/usr/share/bash-completion/completions/_runuser",
+            "/usr/share/bash-completion/completions/_rustup",
+            "/usr/share/bash-completion/completions/_secret-tool",
+            "/usr/share/bash-completion/completions/_slackpkg",
+            "/usr/share/bash-completion/completions/_sops",
+            "/usr/share/bash-completion/completions/_stern",
+            "/usr/share/bash-completion/completions/_stripe",
+            "/usr/share/bash-completion/completions/_su",
+            "/usr/share/bash-completion/completions/_svn",
+            "/usr/share/bash-completion/completions/_svnadmin",
+            "/usr/share/bash-completion/completions/_svnlook",
+            "/usr/share/bash-completion/completions/_task",
+            "/usr/share/bash-completion/completions/_tokio-console",
+            "/usr/share/bash-completion/completions/_udevadm",
+            "/usr/share/bash-completion/completions/_umount",
+            "/usr/share/bash-completion/completions/_umount.linux",
+            "/usr/share/bash-completion/completions/_uvx",
+            "/usr/share/bash-completion/completions/_vault",
+            "/usr/share/bash-completion/completions/_wasmer",
+            "/usr/share/bash-completion/completions/_write",
+            "/usr/share/bash-completion/completions/_xm",
+            "/usr/share/bash-completion/completions/_yq",
+            "/usr/share/bash-completion/completions/_yum",
+            "/usr/share/bash-completion/completions/a2x",
+            "/usr/share/bash-completion/completions/abook",
+            "/usr/share/bash-completion/completions/aclocal",
+            "/usr/share/bash-completion/completions/acpi",
+            "/usr/share/bash-completion/completions/add_members",
+            "/usr/share/bash-completion/completions/alias",
+            "/usr/share/bash-completion/completions/ant",
+            "/usr/share/bash-completion/completions/apache2ctl",
+            "/usr/share/bash-completion/completions/appdata-validate",
+            "/usr/share/bash-completion/completions/apt-build",
+            "/usr/share/bash-completion/completions/apt-cache",
+            "/usr/share/bash-completion/completions/apt-get",
+            "/usr/share/bash-completion/completions/apt-mark",
+            "/usr/share/bash-completion/completions/aptitude",
+            "/usr/share/bash-completion/completions/arch",
+            "/usr/share/bash-completion/completions/arp",
+            "/usr/share/bash-completion/completions/arping",
+            "/usr/share/bash-completion/completions/arpspoof",
+            "/usr/share/bash-completion/completions/asciidoc",
+            "/usr/share/bash-completion/completions/aspell",
+            "/usr/share/bash-completion/completions/autoconf",
+            "/usr/share/bash-completion/completions/automake",
+            "/usr/share/bash-completion/completions/autoreconf",
+            "/usr/share/bash-completion/completions/autorpm",
+            "/usr/share/bash-completion/completions/autoscan",
+            "/usr/share/bash-completion/completions/avahi-browse",
+            "/usr/share/bash-completion/completions/avctrl",
+            "/usr/share/bash-completion/completions/badblocks",
+            "/usr/share/bash-completion/completions/bind",
+            "/usr/share/bash-completion/completions/bk",
+            "/usr/share/bash-completion/completions/brctl",
+            "/usr/share/bash-completion/completions/btdownloadheadless.py",
+            "/usr/share/bash-completion/completions/bzip2",
+            "/usr/share/bash-completion/completions/cancel",
+            "/usr/share/bash-completion/completions/cardctl",
+            "/usr/share/bash-completion/completions/carton",
+            "/usr/share/bash-completion/completions/ccache",
+            "/usr/share/bash-completion/completions/ccze",
+            "/usr/share/bash-completion/completions/cd",
+            "/usr/share/bash-completion/completions/cfagent",
+            "/usr/share/bash-completion/completions/cfrun",
+            "/usr/share/bash-completion/completions/chage",
+            "/usr/share/bash-completion/completions/change_pw",
+            "/usr/share/bash-completion/completions/check_db",
+            "/usr/share/bash-completion/completions/check_perms",
+            "/usr/share/bash-completion/completions/checksec",
+            "/usr/share/bash-completion/completions/chflags",
+            "/usr/share/bash-completion/completions/chgrp",
+            "/usr/share/bash-completion/completions/chkconfig",
+            "/usr/share/bash-completion/completions/chmod",
+            "/usr/share/bash-completion/completions/chown",
+            "/usr/share/bash-completion/completions/chpasswd",
+            "/usr/share/bash-completion/completions/chromium-browser",
+            "/usr/share/bash-completion/completions/chronyc",
+            "/usr/share/bash-completion/completions/chrpath",
+            "/usr/share/bash-completion/completions/cksfv",
+            "/usr/share/bash-completion/completions/cleanarch",
+            "/usr/share/bash-completion/completions/clisp",
+            "/usr/share/bash-completion/completions/clone_member",
+            "/usr/share/bash-completion/completions/complete",
+            "/usr/share/bash-completion/completions/config_list",
+            "/usr/share/bash-completion/completions/configure",
+            "/usr/share/bash-completion/completions/convert",
+            "/usr/share/bash-completion/completions/cowsay",
+            "/usr/share/bash-completion/completions/cpan2dist",
+            "/usr/share/bash-completion/completions/cpio",
+            "/usr/share/bash-completion/completions/cppcheck",
+            "/usr/share/bash-completion/completions/crontab",
+            "/usr/share/bash-completion/completions/cryptsetup",
+            "/usr/share/bash-completion/completions/curl",
+            "/usr/share/bash-completion/completions/cvs",
+            "/usr/share/bash-completion/completions/cvsps",
+            "/usr/share/bash-completion/completions/dd",
+            "/usr/share/bash-completion/completions/declare",
+            "/usr/share/bash-completion/completions/deja-dup",
+            "/usr/share/bash-completion/completions/desktop-file-validate",
+            "/usr/share/bash-completion/completions/dhclient",
+            "/usr/share/bash-completion/completions/dict",
+            "/usr/share/bash-completion/completions/dmypy",
+            "/usr/share/bash-completion/completions/dnssec-keygen",
+            "/usr/share/bash-completion/completions/dnsspoof",
+            "/usr/share/bash-completion/completions/dot",
+            "/usr/share/bash-completion/completions/dpkg",
+            "/usr/share/bash-completion/completions/dpkg-source",
+            "/usr/share/bash-completion/completions/dselect",
+            "/usr/share/bash-completion/completions/dsniff",
+            "/usr/share/bash-completion/completions/dumpdb",
+            "/usr/share/bash-completion/completions/dumpe2fs",
+            "/usr/share/bash-completion/completions/e2freefrag",
+            "/usr/share/bash-completion/completions/e2label",
+            "/usr/share/bash-completion/completions/ebtables",
+            "/usr/share/bash-completion/completions/ecryptfs-migrate-home",
+            "/usr/share/bash-completion/completions/env",
+            "/usr/share/bash-completion/completions/eog",
+            "/usr/share/bash-completion/completions/ether-wake",
+            "/usr/share/bash-completion/completions/evince",
+            "/usr/share/bash-completion/completions/explodepkg",
+            "/usr/share/bash-completion/completions/export",
+            "/usr/share/bash-completion/completions/faillog",
+            "/usr/share/bash-completion/completions/fbgs",
+            "/usr/share/bash-completion/completions/fbi",
+            "/usr/share/bash-completion/completions/feh",
+            "/usr/share/bash-completion/completions/file",
+            "/usr/share/bash-completion/completions/file-roller",
+            "/usr/share/bash-completion/completions/filefrag",
+            "/usr/share/bash-completion/completions/filesnarf",
+            "/usr/share/bash-completion/completions/find",
+            "/usr/share/bash-completion/completions/find_member",
+            "/usr/share/bash-completion/completions/fio",
+            "/usr/share/bash-completion/completions/firefox",
+            "/usr/share/bash-completion/completions/flake8",
+            "/usr/share/bash-completion/completions/fprintd-delete",
+            "/usr/share/bash-completion/completions/fprintd-enroll",
+            "/usr/share/bash-completion/completions/freeciv",
+            "/usr/share/bash-completion/completions/freeciv-server",
+            "/usr/share/bash-completion/completions/function",
+            "/usr/share/bash-completion/completions/fusermount",
+            "/usr/share/bash-completion/completions/gcc",
+            "/usr/share/bash-completion/completions/gcl",
+            "/usr/share/bash-completion/completions/gdb",
+            "/usr/share/bash-completion/completions/genaliases",
+            "/usr/share/bash-completion/completions/gendiff",
+            "/usr/share/bash-completion/completions/genisoimage",
+            "/usr/share/bash-completion/completions/geoiplookup",
+            "/usr/share/bash-completion/completions/getconf",
+            "/usr/share/bash-completion/completions/getent",
+            "/usr/share/bash-completion/completions/gkrellm",
+            "/usr/share/bash-completion/completions/gm",
+            "/usr/share/bash-completion/completions/gnatmake",
+            "/usr/share/bash-completion/completions/gnokii",
+            "/usr/share/bash-completion/completions/gnome-mplayer",
+            "/usr/share/bash-completion/completions/gnome-screenshot",
+            "/usr/share/bash-completion/completions/gpasswd",
+            "/usr/share/bash-completion/completions/gpg",
+            "/usr/share/bash-completion/completions/gpg2",
+            "/usr/share/bash-completion/completions/gpgv",
+            "/usr/share/bash-completion/completions/gphoto2",
+            "/usr/share/bash-completion/completions/gprof",
+            "/usr/share/bash-completion/completions/groupadd",
+            "/usr/share/bash-completion/completions/groupdel",
+            "/usr/share/bash-completion/completions/groupmems",
+            "/usr/share/bash-completion/completions/groupmod",
+            "/usr/share/bash-completion/completions/growisofs",
+            "/usr/share/bash-completion/completions/grpck",
+            "/usr/share/bash-completion/completions/gssdp-discover",
+            "/usr/share/bash-completion/completions/gzip",
+            "/usr/share/bash-completion/completions/hash",
+            "/usr/share/bash-completion/completions/hcitool",
+            "/usr/share/bash-completion/completions/hddtemp",
+            "/usr/share/bash-completion/completions/help",
+            "/usr/share/bash-completion/completions/hid2hci",
+            "/usr/share/bash-completion/completions/hostname",
+            "/usr/share/bash-completion/completions/hping2",
+            "/usr/share/bash-completion/completions/htop",
+            "/usr/share/bash-completion/completions/htpasswd",
+            "/usr/share/bash-completion/completions/hunspell",
+            "/usr/share/bash-completion/completions/iconv",
+            "/usr/share/bash-completion/completions/id",
+            "/usr/share/bash-completion/completions/idn",
+            "/usr/share/bash-completion/completions/ifstat",
+            "/usr/share/bash-completion/completions/iftop",
+            "/usr/share/bash-completion/completions/ifup",
+            "/usr/share/bash-completion/completions/influx",
+            "/usr/share/bash-completion/completions/info",
+            "/usr/share/bash-completion/completions/inject",
+            "/usr/share/bash-completion/completions/inotifywait",
+            "/usr/share/bash-completion/completions/installpkg",
+            "/usr/share/bash-completion/completions/interdiff",
+            "/usr/share/bash-completion/completions/invoke-rc.d",
+            "/usr/share/bash-completion/completions/ip",
+            "/usr/share/bash-completion/completions/ipcalc",
+            "/usr/share/bash-completion/completions/iperf",
+            "/usr/share/bash-completion/completions/ipmitool",
+            "/usr/share/bash-completion/completions/ipsec",
+            "/usr/share/bash-completion/completions/iptables",
+            "/usr/share/bash-completion/completions/ipv6calc",
+            "/usr/share/bash-completion/completions/iscsiadm",
+            "/usr/share/bash-completion/completions/isort",
+            "/usr/share/bash-completion/completions/isql",
+            "/usr/share/bash-completion/completions/iwconfig",
+            "/usr/share/bash-completion/completions/iwlist",
+            "/usr/share/bash-completion/completions/iwpriv",
+            "/usr/share/bash-completion/completions/iwspy",
+            "/usr/share/bash-completion/completions/jar",
+            "/usr/share/bash-completion/completions/jarsigner",
+            "/usr/share/bash-completion/completions/java",
+            "/usr/share/bash-completion/completions/javaws",
+            "/usr/share/bash-completion/completions/jpegoptim",
+            "/usr/share/bash-completion/completions/jps",
+            "/usr/share/bash-completion/completions/jq",
+            "/usr/share/bash-completion/completions/jshint",
+            "/usr/share/bash-completion/completions/json_xs",
+            "/usr/share/bash-completion/completions/jsonschema",
+            "/usr/share/bash-completion/completions/k3b",
+            "/usr/share/bash-completion/completions/kcov",
+            "/usr/share/bash-completion/completions/kill",
+            "/usr/share/bash-completion/completions/killall",
+            "/usr/share/bash-completion/completions/koji",
+            "/usr/share/bash-completion/completions/ktutil",
+            "/usr/share/bash-completion/completions/larch",
+            "/usr/share/bash-completion/completions/lastlog",
+            "/usr/share/bash-completion/completions/ldapsearch",
+            "/usr/share/bash-completion/completions/ldapvi",
+            "/usr/share/bash-completion/completions/lftp",
+            "/usr/share/bash-completion/completions/lftpget",
+            "/usr/share/bash-completion/completions/lilo",
+            "/usr/share/bash-completion/completions/links",
+            "/usr/share/bash-completion/completions/lintian",
+            "/usr/share/bash-completion/completions/lisp",
+            "/usr/share/bash-completion/completions/list_admins",
+            "/usr/share/bash-completion/completions/list_lists",
+            "/usr/share/bash-completion/completions/list_members",
+            "/usr/share/bash-completion/completions/list_owners",
+            "/usr/share/bash-completion/completions/locale-gen",
+            "/usr/share/bash-completion/completions/lpq",
+            "/usr/share/bash-completion/completions/lpr",
+            "/usr/share/bash-completion/completions/lrzip",
+            "/usr/share/bash-completion/completions/lsof",
+            "/usr/share/bash-completion/completions/lsscsi",
+            "/usr/share/bash-completion/completions/lsusb",
+            "/usr/share/bash-completion/completions/lua",
+            "/usr/share/bash-completion/completions/luac",
+            "/usr/share/bash-completion/completions/luseradd",
+            "/usr/share/bash-completion/completions/luserdel",
+            "/usr/share/bash-completion/completions/lvm",
+            "/usr/share/bash-completion/completions/lz4",
+            "/usr/share/bash-completion/completions/lzip",
+            "/usr/share/bash-completion/completions/lzma",
+            "/usr/share/bash-completion/completions/lzop",
+            "/usr/share/bash-completion/completions/macof",
+            "/usr/share/bash-completion/completions/mailmanctl",
+            "/usr/share/bash-completion/completions/make",
+            "/usr/share/bash-completion/completions/makepkg",
+            "/usr/share/bash-completion/completions/man",
+            "/usr/share/bash-completion/completions/mc",
+            "/usr/share/bash-completion/completions/mcrypt",
+            "/usr/share/bash-completion/completions/mdadm",
+            "/usr/share/bash-completion/completions/mdtool",
+            "/usr/share/bash-completion/completions/medusa",
+            "/usr/share/bash-completion/completions/mfiutil",
+            "/usr/share/bash-completion/completions/mii-diag",
+            "/usr/share/bash-completion/completions/mii-tool",
+            "/usr/share/bash-completion/completions/minicom",
+            "/usr/share/bash-completion/completions/mkinitrd",
+            "/usr/share/bash-completion/completions/mktemp",
+            "/usr/share/bash-completion/completions/mmsitepass",
+            "/usr/share/bash-completion/completions/monodevelop",
+            "/usr/share/bash-completion/completions/mplayer",
+            "/usr/share/bash-completion/completions/mr",
+            "/usr/share/bash-completion/completions/msynctool",
+            "/usr/share/bash-completion/completions/mtx",
+            "/usr/share/bash-completion/completions/munin-node-configure",
+            "/usr/share/bash-completion/completions/munin-run",
+            "/usr/share/bash-completion/completions/munin-update",
+            "/usr/share/bash-completion/completions/munindoc",
+            "/usr/share/bash-completion/completions/mussh",
+            "/usr/share/bash-completion/completions/mutt",
+            "/usr/share/bash-completion/completions/mypy",
+            "/usr/share/bash-completion/completions/mysql",
+            "/usr/share/bash-completion/completions/mysqladmin",
+            "/usr/share/bash-completion/completions/nc",
+            "/usr/share/bash-completion/completions/ncftp",
+            "/usr/share/bash-completion/completions/nethogs",
+            "/usr/share/bash-completion/completions/newlist",
+            "/usr/share/bash-completion/completions/newusers",
+            "/usr/share/bash-completion/completions/ngrep",
+            "/usr/share/bash-completion/completions/nmap",
+            "/usr/share/bash-completion/completions/nproc",
+            "/usr/share/bash-completion/completions/nslookup",
+            "/usr/share/bash-completion/completions/nsupdate",
+            "/usr/share/bash-completion/completions/ntpdate",
+            "/usr/share/bash-completion/completions/oggdec",
+            "/usr/share/bash-completion/completions/openssl",
+            "/usr/share/bash-completion/completions/opera",
+            "/usr/share/bash-completion/completions/optipng",
+            "/usr/share/bash-completion/completions/p4",
+            "/usr/share/bash-completion/completions/pack200",
+            "/usr/share/bash-completion/completions/passwd",
+            "/usr/share/bash-completion/completions/patch",
+            "/usr/share/bash-completion/completions/pdftoppm",
+            "/usr/share/bash-completion/completions/pdftotext",
+            "/usr/share/bash-completion/completions/perl",
+            "/usr/share/bash-completion/completions/perlcritic",
+            "/usr/share/bash-completion/completions/perltidy",
+            "/usr/share/bash-completion/completions/pgrep",
+            "/usr/share/bash-completion/completions/pidof",
+            "/usr/share/bash-completion/completions/pine",
+            "/usr/share/bash-completion/completions/ping",
+            "/usr/share/bash-completion/completions/pkg-config",
+            "/usr/share/bash-completion/completions/pkg-get",
+            "/usr/share/bash-completion/completions/pkgadd",
+            "/usr/share/bash-completion/completions/pkgrm",
+            "/usr/share/bash-completion/completions/pkgtool",
+            "/usr/share/bash-completion/completions/plague-client",
+            "/usr/share/bash-completion/completions/pm-hibernate",
+            "/usr/share/bash-completion/completions/pm-is-supported",
+            "/usr/share/bash-completion/completions/pm-powersave",
+            "/usr/share/bash-completion/completions/pngfix",
+            "/usr/share/bash-completion/completions/postcat",
+            "/usr/share/bash-completion/completions/postconf",
+            "/usr/share/bash-completion/completions/postfix",
+            "/usr/share/bash-completion/completions/postmap",
+            "/usr/share/bash-completion/completions/postsuper",
+            "/usr/share/bash-completion/completions/povray",
+            "/usr/share/bash-completion/completions/prelink",
+            "/usr/share/bash-completion/completions/printenv",
+            "/usr/share/bash-completion/completions/protoc",
+            "/usr/share/bash-completion/completions/ps",
+            "/usr/share/bash-completion/completions/psql",
+            "/usr/share/bash-completion/completions/puppet",
+            "/usr/share/bash-completion/completions/pv",
+            "/usr/share/bash-completion/completions/pwck",
+            "/usr/share/bash-completion/completions/pwd",
+            "/usr/share/bash-completion/completions/pwdx",
+            "/usr/share/bash-completion/completions/pwgen",
+            "/usr/share/bash-completion/completions/pycodestyle",
+            "/usr/share/bash-completion/completions/pydoc",
+            "/usr/share/bash-completion/completions/pydocstyle",
+            "/usr/share/bash-completion/completions/pyflakes",
+            "/usr/share/bash-completion/completions/pylint",
+            "/usr/share/bash-completion/completions/pytest",
+            "/usr/share/bash-completion/completions/python",
+            "/usr/share/bash-completion/completions/pyvenv",
+            "/usr/share/bash-completion/completions/qdbus",
+            "/usr/share/bash-completion/completions/qemu",
+            "/usr/share/bash-completion/completions/qrunner",
+            "/usr/share/bash-completion/completions/querybts",
+            "/usr/share/bash-completion/completions/quota",
+            "/usr/share/bash-completion/completions/radvdump",
+            "/usr/share/bash-completion/completions/rcs",
+            "/usr/share/bash-completion/completions/rdesktop",
+            "/usr/share/bash-completion/completions/remove_members",
+            "/usr/share/bash-completion/completions/removepkg",
+            "/usr/share/bash-completion/completions/reportbug",
+            "/usr/share/bash-completion/completions/resolvconf",
+            "/usr/share/bash-completion/completions/ri",
+            "/usr/share/bash-completion/completions/rmlist",
+            "/usr/share/bash-completion/completions/route",
+            "/usr/share/bash-completion/completions/rpcdebug",
+            "/usr/share/bash-completion/completions/rpm",
+            "/usr/share/bash-completion/completions/rpm2tgz",
+            "/usr/share/bash-completion/completions/rpmcheck",
+            "/usr/share/bash-completion/completions/rrdtool",
+            "/usr/share/bash-completion/completions/rsync",
+            "/usr/share/bash-completion/completions/sbcl",
+            "/usr/share/bash-completion/completions/sbopkg",
+            "/usr/share/bash-completion/completions/screen",
+            "/usr/share/bash-completion/completions/scrub",
+            "/usr/share/bash-completion/completions/set",
+            "/usr/share/bash-completion/completions/sh",
+            "/usr/share/bash-completion/completions/sha256sum",
+            "/usr/share/bash-completion/completions/shellcheck",
+            "/usr/share/bash-completion/completions/sitecopy",
+            "/usr/share/bash-completion/completions/slabtop",
+            "/usr/share/bash-completion/completions/slapt-get",
+            "/usr/share/bash-completion/completions/slapt-src",
+            "/usr/share/bash-completion/completions/smartctl",
+            "/usr/share/bash-completion/completions/smbclient",
+            "/usr/share/bash-completion/completions/snownews",
+            "/usr/share/bash-completion/completions/sqlite3",
+            "/usr/share/bash-completion/completions/ss",
+            "/usr/share/bash-completion/completions/ssh",
+            "/usr/share/bash-completion/completions/ssh-add",
+            "/usr/share/bash-completion/completions/ssh-copy-id",
+            "/usr/share/bash-completion/completions/ssh-keygen",
+            "/usr/share/bash-completion/completions/ssh-keyscan",
+            "/usr/share/bash-completion/completions/sshfs",
+            "/usr/share/bash-completion/completions/sshmitm",
+            "/usr/share/bash-completion/completions/sshow",
+            "/usr/share/bash-completion/completions/strace",
+            "/usr/share/bash-completion/completions/strings",
+            "/usr/share/bash-completion/completions/sudo",
+            "/usr/share/bash-completion/completions/svcadm",
+            "/usr/share/bash-completion/completions/svk",
+            "/usr/share/bash-completion/completions/sync_members",
+            "/usr/share/bash-completion/completions/synclient",
+            "/usr/share/bash-completion/completions/sysbench",
+            "/usr/share/bash-completion/completions/sysctl",
+            "/usr/share/bash-completion/completions/tar",
+            "/usr/share/bash-completion/completions/tcpdump",
+            "/usr/share/bash-completion/completions/tcpkill",
+            "/usr/share/bash-completion/completions/tcpnice",
+            "/usr/share/bash-completion/completions/timeout",
+            "/usr/share/bash-completion/completions/tipc",
+            "/usr/share/bash-completion/completions/tox",
+            "/usr/share/bash-completion/completions/tracepath",
+            "/usr/share/bash-completion/completions/tree",
+            "/usr/share/bash-completion/completions/truncate",
+            "/usr/share/bash-completion/completions/tshark",
+            "/usr/share/bash-completion/completions/tsig-keygen",
+            "/usr/share/bash-completion/completions/tune2fs",
+            "/usr/share/bash-completion/completions/ulimit",
+            "/usr/share/bash-completion/completions/unace",
+            "/usr/share/bash-completion/completions/unpack200",
+            "/usr/share/bash-completion/completions/unrar",
+            "/usr/share/bash-completion/completions/unshunt",
+            "/usr/share/bash-completion/completions/update-alternatives",
+            "/usr/share/bash-completion/completions/update-rc.d",
+            "/usr/share/bash-completion/completions/upgradepkg",
+            "/usr/share/bash-completion/completions/urlsnarf",
+            "/usr/share/bash-completion/completions/useradd",
+            "/usr/share/bash-completion/completions/userdel",
+            "/usr/share/bash-completion/completions/usermod",
+            "/usr/share/bash-completion/completions/valgrind",
+            "/usr/share/bash-completion/completions/vipw",
+            "/usr/share/bash-completion/completions/vmstat",
+            "/usr/share/bash-completion/completions/vncviewer",
+            "/usr/share/bash-completion/completions/vpnc",
+            "/usr/share/bash-completion/completions/watch",
+            "/usr/share/bash-completion/completions/webmitm",
+            "/usr/share/bash-completion/completions/wget",
+            "/usr/share/bash-completion/completions/wine",
+            "/usr/share/bash-completion/completions/withlist",
+            "/usr/share/bash-completion/completions/wodim",
+            "/usr/share/bash-completion/completions/wol",
+            "/usr/share/bash-completion/completions/wsimport",
+            "/usr/share/bash-completion/completions/wtf",
+            "/usr/share/bash-completion/completions/wvdial",
+            "/usr/share/bash-completion/completions/xdg-mime",
+            "/usr/share/bash-completion/completions/xdg-settings",
+            "/usr/share/bash-completion/completions/xev",
+            "/usr/share/bash-completion/completions/xfreerdp",
+            "/usr/share/bash-completion/completions/xgamma",
+            "/usr/share/bash-completion/completions/xhost",
+            "/usr/share/bash-completion/completions/xmllint",
+            "/usr/share/bash-completion/completions/xmlwf",
+            "/usr/share/bash-completion/completions/xmms",
+            "/usr/share/bash-completion/completions/xmodmap",
+            "/usr/share/bash-completion/completions/xrandr",
+            "/usr/share/bash-completion/completions/xrdb",
+            "/usr/share/bash-completion/completions/xsltproc",
+            "/usr/share/bash-completion/completions/xvfb-run",
+            "/usr/share/bash-completion/completions/xxd",
+            "/usr/share/bash-completion/completions/xz",
+            "/usr/share/bash-completion/completions/xzdec",
+            "/usr/share/bash-completion/completions/ypmatch",
+            "/usr/share/bash-completion/completions/yum-arch",
+            "/usr/share/bash-completion/completions/zopfli",
+            "/usr/share/bash-completion/completions/zopflipng",
+            "/usr/share/bash-completion/helpers/make-extract-targets.awk",
+            "/usr/share/bash-completion/helpers/perl",
+            "/usr/share/bash-completion/helpers/python",
+            "/usr/share/cmake/bash-completion/bash-completion-config-version.cmake",
+            "/usr/share/cmake/bash-completion/bash-completion-config.cmake",
+            "/usr/share/doc/bash-completion/AUTHORS",
+            "/usr/share/doc/bash-completion/CONTRIBUTING.md.gz",
+            "/usr/share/doc/bash-completion/README.Debian",
+            "/usr/share/doc/bash-completion/README.md.gz",
+            "/usr/share/doc/bash-completion/changelog.Debian.gz",
+            "/usr/share/doc/bash-completion/changelog.gz",
+            "/usr/share/doc/bash-completion/copyright",
+            "/usr/share/lintian/overrides/bash-completion",
+            "/usr/share/man/man1/dh_bash-completion.1.gz",
+            "/usr/share/perl5/Debian/Debhelper/Sequence/bash_completion.pm",
+            "/usr/share/pkgconfig/bash-completion.pc"
+          ]
+        },
+        {
+          "ID": "bsdutils@1:2.41-5",
+          "Name": "bsdutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/bsdutils@2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "c9de60be80a96a27"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/logger",
+            "/usr/bin/renice",
+            "/usr/bin/script",
+            "/usr/bin/scriptlive",
+            "/usr/bin/scriptreplay",
+            "/usr/bin/wall",
+            "/usr/share/bash-completion/completions/logger",
+            "/usr/share/bash-completion/completions/renice",
+            "/usr/share/bash-completion/completions/script",
+            "/usr/share/bash-completion/completions/scriptlive",
+            "/usr/share/bash-completion/completions/scriptreplay",
+            "/usr/share/bash-completion/completions/wall",
+            "/usr/share/doc/bsdutils/NEWS.Debian.gz",
+            "/usr/share/doc/bsdutils/changelog.Debian.gz",
+            "/usr/share/doc/bsdutils/changelog.gz",
+            "/usr/share/doc/bsdutils/copyright",
+            "/usr/share/lintian/overrides/bsdutils",
+            "/usr/share/man/man1/logger.1.gz",
+            "/usr/share/man/man1/renice.1.gz",
+            "/usr/share/man/man1/script.1.gz",
+            "/usr/share/man/man1/scriptlive.1.gz",
+            "/usr/share/man/man1/scriptreplay.1.gz",
+            "/usr/share/man/man1/wall.1.gz"
+          ]
+        },
+        {
+          "ID": "ca-certificates@20250419",
+          "Name": "ca-certificates",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/ca-certificates@20250419?arch=all\u0026distro=debian-13.1",
+            "UID": "bcbbfb6dcdbd65a7"
+          },
+          "Version": "20250419",
+          "Arch": "all",
+          "SrcName": "ca-certificates",
+          "SrcVersion": "20250419",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "MPL-2.0"
+          ],
+          "Maintainer": "Julien Cristau \u003cjcristau@debian.org\u003e",
+          "DependsOn": [
+            "debconf@1.5.91",
+            "openssl@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93"
+          },
+          "InstalledFiles": [
+            "/usr/sbin/update-ca-certificates",
+            "/usr/share/ca-certificates/mozilla/ACCVRAIZ1.crt",
+            "/usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM.crt",
+            "/usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.crt",
+            "/usr/share/ca-certificates/mozilla/ANF_Secure_Server_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Actalis_Authentication_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/AffirmTrust_Commercial.crt",
+            "/usr/share/ca-certificates/mozilla/AffirmTrust_Networking.crt",
+            "/usr/share/ca-certificates/mozilla/AffirmTrust_Premium.crt",
+            "/usr/share/ca-certificates/mozilla/AffirmTrust_Premium_ECC.crt",
+            "/usr/share/ca-certificates/mozilla/Amazon_Root_CA_1.crt",
+            "/usr/share/ca-certificates/mozilla/Amazon_Root_CA_2.crt",
+            "/usr/share/ca-certificates/mozilla/Amazon_Root_CA_3.crt",
+            "/usr/share/ca-certificates/mozilla/Amazon_Root_CA_4.crt",
+            "/usr/share/ca-certificates/mozilla/Atos_TrustedRoot_2011.crt",
+            "/usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.crt",
+            "/usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.crt",
+            "/usr/share/ca-certificates/mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt",
+            "/usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA1.crt",
+            "/usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA2.crt",
+            "/usr/share/ca-certificates/mozilla/Baltimore_CyberTrust_Root.crt",
+            "/usr/share/ca-certificates/mozilla/Buypass_Class_2_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Buypass_Class_3_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/CA_Disig_Root_R2.crt",
+            "/usr/share/ca-certificates/mozilla/CFCA_EV_ROOT.crt",
+            "/usr/share/ca-certificates/mozilla/COMODO_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/COMODO_ECC_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/COMODO_RSA_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/Certainly_Root_E1.crt",
+            "/usr/share/ca-certificates/mozilla/Certainly_Root_R1.crt",
+            "/usr/share/ca-certificates/mozilla/Certigna.crt",
+            "/usr/share/ca-certificates/mozilla/Certigna_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Certum_EC-384_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA_2.crt",
+            "/usr/share/ca-certificates/mozilla/Certum_Trusted_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-01.crt",
+            "/usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-02.crt",
+            "/usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-01.crt",
+            "/usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-02.crt",
+            "/usr/share/ca-certificates/mozilla/Comodo_AAA_Services_root.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_1_2020.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_2_2023.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_1_2020.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_2_2023.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt",
+            "/usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G2.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G3.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Global_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G2.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G3.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_High_Assurance_EV_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_TLS_ECC_P384_Root_G5.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_TLS_RSA4096_Root_G5.crt",
+            "/usr/share/ca-certificates/mozilla/DigiCert_Trusted_Root_G4.crt",
+            "/usr/share/ca-certificates/mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_EC1.crt",
+            "/usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_G2.crt",
+            "/usr/share/ca-certificates/mozilla/FIRMAPROFESIONAL_CA_ROOT-A_WEB.crt",
+            "/usr/share/ca-certificates/mozilla/GDCA_TrustAUTH_R5_ROOT.crt",
+            "/usr/share/ca-certificates/mozilla/GLOBALTRUST_2020.crt",
+            "/usr/share/ca-certificates/mozilla/GTS_Root_R1.crt",
+            "/usr/share/ca-certificates/mozilla/GTS_Root_R2.crt",
+            "/usr/share/ca-certificates/mozilla/GTS_Root_R3.crt",
+            "/usr/share/ca-certificates/mozilla/GTS_Root_R4.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R4.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R5.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R3.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R6.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_Root_E46.crt",
+            "/usr/share/ca-certificates/mozilla/GlobalSign_Root_R46.crt",
+            "/usr/share/ca-certificates/mozilla/Go_Daddy_Class_2_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt",
+            "/usr/share/ca-certificates/mozilla/HARICA_TLS_ECC_Root_CA_2021.crt",
+            "/usr/share/ca-certificates/mozilla/HARICA_TLS_RSA_Root_CA_2021.crt",
+            "/usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt",
+            "/usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt",
+            "/usr/share/ca-certificates/mozilla/HiPKI_Root_CA_-_G1.crt",
+            "/usr/share/ca-certificates/mozilla/Hongkong_Post_Root_CA_3.crt",
+            "/usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt",
+            "/usr/share/ca-certificates/mozilla/ISRG_Root_X2.crt",
+            "/usr/share/ca-certificates/mozilla/IdenTrust_Commercial_Root_CA_1.crt",
+            "/usr/share/ca-certificates/mozilla/IdenTrust_Public_Sector_Root_CA_1.crt",
+            "/usr/share/ca-certificates/mozilla/Izenpe.com.crt",
+            "/usr/share/ca-certificates/mozilla/Microsec_e-Szigno_Root_CA_2009.crt",
+            "/usr/share/ca-certificates/mozilla/Microsoft_ECC_Root_Certificate_Authority_2017.crt",
+            "/usr/share/ca-certificates/mozilla/Microsoft_RSA_Root_Certificate_Authority_2017.crt",
+            "/usr/share/ca-certificates/mozilla/NAVER_Global_Root_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt",
+            "/usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt",
+            "/usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GC_CA.crt",
+            "/usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_1_G3.crt",
+            "/usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2.crt",
+            "/usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2_G3.crt",
+            "/usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3.crt",
+            "/usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3_G3.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_ECC.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_ECC.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_RSA.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_TLS_ECC_Root_CA_2022.crt",
+            "/usr/share/ca-certificates/mozilla/SSL.com_TLS_RSA_Root_CA_2022.crt",
+            "/usr/share/ca-certificates/mozilla/SZAFIR_ROOT_CA2.crt",
+            "/usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_E46.crt",
+            "/usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_R46.crt",
+            "/usr/share/ca-certificates/mozilla/SecureSign_Root_CA12.crt",
+            "/usr/share/ca-certificates/mozilla/SecureSign_Root_CA14.crt",
+            "/usr/share/ca-certificates/mozilla/SecureSign_Root_CA15.crt",
+            "/usr/share/ca-certificates/mozilla/SecureTrust_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Secure_Global_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Security_Communication_ECC_RootCA1.crt",
+            "/usr/share/ca-certificates/mozilla/Security_Communication_RootCA2.crt",
+            "/usr/share/ca-certificates/mozilla/Starfield_Class_2_CA.crt",
+            "/usr/share/ca-certificates/mozilla/Starfield_Root_Certificate_Authority_-_G2.crt",
+            "/usr/share/ca-certificates/mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt",
+            "/usr/share/ca-certificates/mozilla/SwissSign_Gold_CA_-_G2.crt",
+            "/usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_2.crt",
+            "/usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_3.crt",
+            "/usr/share/ca-certificates/mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt",
+            "/usr/share/ca-certificates/mozilla/TWCA_CYBER_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/TWCA_Global_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/TWCA_Root_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/Telekom_Security_TLS_ECC_Root_2020.crt",
+            "/usr/share/ca-certificates/mozilla/Telekom_Security_TLS_RSA_Root_2023.crt",
+            "/usr/share/ca-certificates/mozilla/TeliaSonera_Root_CA_v1.crt",
+            "/usr/share/ca-certificates/mozilla/Telia_Root_CA_v2.crt",
+            "/usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G3.crt",
+            "/usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G4.crt",
+            "/usr/share/ca-certificates/mozilla/Trustwave_Global_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P256_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P384_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/TunTrust_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/UCA_Extended_Validation_Root.crt",
+            "/usr/share/ca-certificates/mozilla/UCA_Global_G2_Root.crt",
+            "/usr/share/ca-certificates/mozilla/USERTrust_ECC_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/USERTrust_RSA_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/XRamp_Global_CA_Root.crt",
+            "/usr/share/ca-certificates/mozilla/certSIGN_ROOT_CA.crt",
+            "/usr/share/ca-certificates/mozilla/certSIGN_Root_CA_G2.crt",
+            "/usr/share/ca-certificates/mozilla/e-Szigno_Root_CA_2017.crt",
+            "/usr/share/ca-certificates/mozilla/ePKI_Root_Certification_Authority.crt",
+            "/usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_C3.crt",
+            "/usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_G3.crt",
+            "/usr/share/ca-certificates/mozilla/emSign_Root_CA_-_C1.crt",
+            "/usr/share/ca-certificates/mozilla/emSign_Root_CA_-_G1.crt",
+            "/usr/share/ca-certificates/mozilla/vTrus_ECC_Root_CA.crt",
+            "/usr/share/ca-certificates/mozilla/vTrus_Root_CA.crt",
+            "/usr/share/doc/ca-certificates/README.Debian",
+            "/usr/share/doc/ca-certificates/changelog.gz",
+            "/usr/share/doc/ca-certificates/copyright",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/Makefile",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/README",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/ca-certificates-local.triggers",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/changelog",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/compat",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/control",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/postrm",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/rules",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/source/format",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/local/Local_Root_CA.crt",
+            "/usr/share/doc/ca-certificates/examples/ca-certificates-local/local/Makefile",
+            "/usr/share/man/man8/update-ca-certificates.8.gz"
+          ]
+        },
+        {
+          "ID": "coreutils@9.7-3",
+          "Name": "coreutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/coreutils@9.7-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a90cbdbcbab1768e"
+          },
+          "Version": "9.7",
+          "Release": "3",
+          "Arch": "amd64",
+          "SrcName": "coreutils",
+          "SrcVersion": "9.7",
+          "SrcRelease": "3",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "BSD-4-Clause-UC",
+            "GPL-3.0-only",
+            "ISC",
+            "FSFULLR",
+            "GFDL-1.3-no-invariants-only",
+            "GFDL-1.3-only"
+          ],
+          "Maintainer": "Michael Stone \u003cmstone@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/[",
+            "/usr/bin/arch",
+            "/usr/bin/b2sum",
+            "/usr/bin/base32",
+            "/usr/bin/base64",
+            "/usr/bin/basename",
+            "/usr/bin/basenc",
+            "/usr/bin/cat",
+            "/usr/bin/chcon",
+            "/usr/bin/chgrp",
+            "/usr/bin/chmod",
+            "/usr/bin/chown",
+            "/usr/bin/cksum",
+            "/usr/bin/comm",
+            "/usr/bin/cp",
+            "/usr/bin/csplit",
+            "/usr/bin/cut",
+            "/usr/bin/date",
+            "/usr/bin/dd",
+            "/usr/bin/df",
+            "/usr/bin/dir",
+            "/usr/bin/dircolors",
+            "/usr/bin/dirname",
+            "/usr/bin/du",
+            "/usr/bin/echo",
+            "/usr/bin/env",
+            "/usr/bin/expand",
+            "/usr/bin/expr",
+            "/usr/bin/factor",
+            "/usr/bin/false",
+            "/usr/bin/fmt",
+            "/usr/bin/fold",
+            "/usr/bin/groups",
+            "/usr/bin/head",
+            "/usr/bin/hostid",
+            "/usr/bin/id",
+            "/usr/bin/install",
+            "/usr/bin/join",
+            "/usr/bin/link",
+            "/usr/bin/ln",
+            "/usr/bin/logname",
+            "/usr/bin/ls",
+            "/usr/bin/md5sum",
+            "/usr/bin/mkdir",
+            "/usr/bin/mkfifo",
+            "/usr/bin/mknod",
+            "/usr/bin/mktemp",
+            "/usr/bin/mv",
+            "/usr/bin/nice",
+            "/usr/bin/nl",
+            "/usr/bin/nohup",
+            "/usr/bin/nproc",
+            "/usr/bin/numfmt",
+            "/usr/bin/od",
+            "/usr/bin/paste",
+            "/usr/bin/pathchk",
+            "/usr/bin/pinky",
+            "/usr/bin/pr",
+            "/usr/bin/printenv",
+            "/usr/bin/printf",
+            "/usr/bin/ptx",
+            "/usr/bin/pwd",
+            "/usr/bin/readlink",
+            "/usr/bin/realpath",
+            "/usr/bin/rm",
+            "/usr/bin/rmdir",
+            "/usr/bin/runcon",
+            "/usr/bin/seq",
+            "/usr/bin/sha1sum",
+            "/usr/bin/sha224sum",
+            "/usr/bin/sha256sum",
+            "/usr/bin/sha384sum",
+            "/usr/bin/sha512sum",
+            "/usr/bin/shred",
+            "/usr/bin/shuf",
+            "/usr/bin/sleep",
+            "/usr/bin/sort",
+            "/usr/bin/split",
+            "/usr/bin/stat",
+            "/usr/bin/stdbuf",
+            "/usr/bin/stty",
+            "/usr/bin/sum",
+            "/usr/bin/sync",
+            "/usr/bin/tac",
+            "/usr/bin/tail",
+            "/usr/bin/tee",
+            "/usr/bin/test",
+            "/usr/bin/timeout",
+            "/usr/bin/touch",
+            "/usr/bin/tr",
+            "/usr/bin/true",
+            "/usr/bin/truncate",
+            "/usr/bin/tsort",
+            "/usr/bin/tty",
+            "/usr/bin/uname",
+            "/usr/bin/unexpand",
+            "/usr/bin/uniq",
+            "/usr/bin/unlink",
+            "/usr/bin/users",
+            "/usr/bin/vdir",
+            "/usr/bin/wc",
+            "/usr/bin/who",
+            "/usr/bin/whoami",
+            "/usr/bin/yes",
+            "/usr/libexec/coreutils/libstdbuf.so",
+            "/usr/sbin/chroot",
+            "/usr/share/doc/coreutils/AUTHORS",
+            "/usr/share/doc/coreutils/NEWS.gz",
+            "/usr/share/doc/coreutils/README.Debian",
+            "/usr/share/doc/coreutils/README.gz",
+            "/usr/share/doc/coreutils/THANKS.gz",
+            "/usr/share/doc/coreutils/TODO.gz",
+            "/usr/share/doc/coreutils/changelog.Debian.gz",
+            "/usr/share/doc/coreutils/changelog.gz",
+            "/usr/share/doc/coreutils/copyright",
+            "/usr/share/info/coreutils.info.gz",
+            "/usr/share/lintian/overrides/coreutils",
+            "/usr/share/locale/af/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/be/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/da/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/de/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/el/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/es/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/et/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ia/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/id/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/it/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/kk/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/lg/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/ta/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/coreutils.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/coreutils.mo",
+            "/usr/share/man/man1/arch.1.gz",
+            "/usr/share/man/man1/b2sum.1.gz",
+            "/usr/share/man/man1/base32.1.gz",
+            "/usr/share/man/man1/base64.1.gz",
+            "/usr/share/man/man1/basename.1.gz",
+            "/usr/share/man/man1/basenc.1.gz",
+            "/usr/share/man/man1/cat.1.gz",
+            "/usr/share/man/man1/chcon.1.gz",
+            "/usr/share/man/man1/chgrp.1.gz",
+            "/usr/share/man/man1/chmod.1.gz",
+            "/usr/share/man/man1/chown.1.gz",
+            "/usr/share/man/man1/cksum.1.gz",
+            "/usr/share/man/man1/comm.1.gz",
+            "/usr/share/man/man1/cp.1.gz",
+            "/usr/share/man/man1/csplit.1.gz",
+            "/usr/share/man/man1/cut.1.gz",
+            "/usr/share/man/man1/date.1.gz",
+            "/usr/share/man/man1/dd.1.gz",
+            "/usr/share/man/man1/df.1.gz",
+            "/usr/share/man/man1/dir.1.gz",
+            "/usr/share/man/man1/dircolors.1.gz",
+            "/usr/share/man/man1/dirname.1.gz",
+            "/usr/share/man/man1/du.1.gz",
+            "/usr/share/man/man1/echo.1.gz",
+            "/usr/share/man/man1/env.1.gz",
+            "/usr/share/man/man1/expand.1.gz",
+            "/usr/share/man/man1/expr.1.gz",
+            "/usr/share/man/man1/factor.1.gz",
+            "/usr/share/man/man1/false.1.gz",
+            "/usr/share/man/man1/fmt.1.gz",
+            "/usr/share/man/man1/fold.1.gz",
+            "/usr/share/man/man1/groups.1.gz",
+            "/usr/share/man/man1/head.1.gz",
+            "/usr/share/man/man1/hostid.1.gz",
+            "/usr/share/man/man1/id.1.gz",
+            "/usr/share/man/man1/install.1.gz",
+            "/usr/share/man/man1/join.1.gz",
+            "/usr/share/man/man1/link.1.gz",
+            "/usr/share/man/man1/ln.1.gz",
+            "/usr/share/man/man1/logname.1.gz",
+            "/usr/share/man/man1/ls.1.gz",
+            "/usr/share/man/man1/md5sum.1.gz",
+            "/usr/share/man/man1/mkdir.1.gz",
+            "/usr/share/man/man1/mkfifo.1.gz",
+            "/usr/share/man/man1/mknod.1.gz",
+            "/usr/share/man/man1/mktemp.1.gz",
+            "/usr/share/man/man1/mv.1.gz",
+            "/usr/share/man/man1/nice.1.gz",
+            "/usr/share/man/man1/nl.1.gz",
+            "/usr/share/man/man1/nohup.1.gz",
+            "/usr/share/man/man1/nproc.1.gz",
+            "/usr/share/man/man1/numfmt.1.gz",
+            "/usr/share/man/man1/od.1.gz",
+            "/usr/share/man/man1/paste.1.gz",
+            "/usr/share/man/man1/pathchk.1.gz",
+            "/usr/share/man/man1/pinky.1.gz",
+            "/usr/share/man/man1/pr.1.gz",
+            "/usr/share/man/man1/printenv.1.gz",
+            "/usr/share/man/man1/printf.1.gz",
+            "/usr/share/man/man1/ptx.1.gz",
+            "/usr/share/man/man1/pwd.1.gz",
+            "/usr/share/man/man1/readlink.1.gz",
+            "/usr/share/man/man1/realpath.1.gz",
+            "/usr/share/man/man1/rm.1.gz",
+            "/usr/share/man/man1/rmdir.1.gz",
+            "/usr/share/man/man1/runcon.1.gz",
+            "/usr/share/man/man1/seq.1.gz",
+            "/usr/share/man/man1/sha1sum.1.gz",
+            "/usr/share/man/man1/sha224sum.1.gz",
+            "/usr/share/man/man1/sha256sum.1.gz",
+            "/usr/share/man/man1/sha384sum.1.gz",
+            "/usr/share/man/man1/sha512sum.1.gz",
+            "/usr/share/man/man1/shred.1.gz",
+            "/usr/share/man/man1/shuf.1.gz",
+            "/usr/share/man/man1/sleep.1.gz",
+            "/usr/share/man/man1/sort.1.gz",
+            "/usr/share/man/man1/split.1.gz",
+            "/usr/share/man/man1/stat.1.gz",
+            "/usr/share/man/man1/stdbuf.1.gz",
+            "/usr/share/man/man1/stty.1.gz",
+            "/usr/share/man/man1/sum.1.gz",
+            "/usr/share/man/man1/sync.1.gz",
+            "/usr/share/man/man1/tac.1.gz",
+            "/usr/share/man/man1/tail.1.gz",
+            "/usr/share/man/man1/tee.1.gz",
+            "/usr/share/man/man1/test.1.gz",
+            "/usr/share/man/man1/timeout.1.gz",
+            "/usr/share/man/man1/touch.1.gz",
+            "/usr/share/man/man1/tr.1.gz",
+            "/usr/share/man/man1/true.1.gz",
+            "/usr/share/man/man1/truncate.1.gz",
+            "/usr/share/man/man1/tsort.1.gz",
+            "/usr/share/man/man1/tty.1.gz",
+            "/usr/share/man/man1/uname.1.gz",
+            "/usr/share/man/man1/unexpand.1.gz",
+            "/usr/share/man/man1/uniq.1.gz",
+            "/usr/share/man/man1/unlink.1.gz",
+            "/usr/share/man/man1/users.1.gz",
+            "/usr/share/man/man1/vdir.1.gz",
+            "/usr/share/man/man1/wc.1.gz",
+            "/usr/share/man/man1/who.1.gz",
+            "/usr/share/man/man1/whoami.1.gz",
+            "/usr/share/man/man1/yes.1.gz",
+            "/usr/share/man/man8/chroot.8.gz"
+          ]
+        },
+        {
+          "ID": "curl@8.14.1-2+deb13u2",
+          "Name": "curl",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/curl@8.14.1-2%2Bdeb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d75e0bb035cd8a38"
+          },
+          "Version": "8.14.1",
+          "Release": "2+deb13u2",
+          "Arch": "amd64",
+          "SrcName": "curl",
+          "SrcVersion": "8.14.1",
+          "SrcRelease": "2+deb13u2",
+          "Licenses": [
+            "curl",
+            "OLDAP-2.8",
+            "ISC",
+            "GPL-2+ with Autoconf-data exception",
+            "GPL-3+ with Autoconf-data exception",
+            "GPL-2+ with Libtool exception",
+            "BSD-3-Clause",
+            "BSD-4-Clause-UC",
+            "FSFULLR",
+            "X11",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian Curl Maintainers \u003cteam+curl@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libcurl4t64@8.14.1-2+deb13u2",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/bin/curl",
+            "/usr/bin/wcurl",
+            "/usr/share/doc/curl/NEWS.Debian.gz",
+            "/usr/share/doc/curl/README.Debian",
+            "/usr/share/doc/curl/changelog.Debian.gz",
+            "/usr/share/doc/curl/changelog.gz",
+            "/usr/share/doc/curl/copyright",
+            "/usr/share/fish/vendor_completions.d/curl.fish",
+            "/usr/share/man/man1/curl.1.gz",
+            "/usr/share/man/man1/wcurl.1.gz",
+            "/usr/share/zsh/vendor-completions/_curl"
+          ]
+        },
+        {
+          "ID": "dash@0.5.12-12",
+          "Name": "dash",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/dash@0.5.12-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "89c835b0985cdc5c"
+          },
+          "Version": "0.5.12",
+          "Release": "12",
+          "Arch": "amd64",
+          "SrcName": "dash",
+          "SrcVersion": "0.5.12",
+          "SrcRelease": "12",
+          "Licenses": [
+            "BSD-3-Clause",
+            "public-domain",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Andrej Shadura \u003candrewsh@debian.org\u003e",
+          "DependsOn": [
+            "debianutils@5.23.2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/dash",
+            "/usr/share/debianutils/shells.d/dash",
+            "/usr/share/doc/dash/README.Debian.diet",
+            "/usr/share/doc/dash/README.source",
+            "/usr/share/doc/dash/changelog.Debian.gz",
+            "/usr/share/doc/dash/changelog.gz",
+            "/usr/share/doc/dash/copyright",
+            "/usr/share/lintian/overrides/dash",
+            "/usr/share/man/man1/dash.1.gz",
+            "/usr/share/menu/dash"
+          ]
+        },
+        {
+          "ID": "debconf@1.5.91",
+          "Name": "debconf",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/debconf@1.5.91?arch=all\u0026distro=debian-13.1",
+            "UID": "dbd74d1c32616a65"
+          },
+          "Version": "1.5.91",
+          "Arch": "all",
+          "SrcName": "debconf",
+          "SrcVersion": "1.5.91",
+          "Licenses": [
+            "BSD-2-Clause"
+          ],
+          "Maintainer": "Debconf Developers \u003cdebconf-devel@lists.alioth.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/debconf",
+            "/usr/bin/debconf-apt-progress",
+            "/usr/bin/debconf-communicate",
+            "/usr/bin/debconf-copydb",
+            "/usr/bin/debconf-escape",
+            "/usr/bin/debconf-set-selections",
+            "/usr/bin/debconf-show",
+            "/usr/sbin/dpkg-preconfigure",
+            "/usr/sbin/dpkg-reconfigure",
+            "/usr/share/bash-completion/completions/debconf",
+            "/usr/share/debconf/confmodule",
+            "/usr/share/debconf/confmodule.sh",
+            "/usr/share/debconf/debconf.conf",
+            "/usr/share/debconf/fix_db.pl",
+            "/usr/share/debconf/frontend",
+            "/usr/share/doc/debconf/README.Debian",
+            "/usr/share/doc/debconf/changelog.gz",
+            "/usr/share/doc/debconf/copyright",
+            "/usr/share/lintian/overrides/debconf",
+            "/usr/share/man/man1/debconf-apt-progress.1.gz",
+            "/usr/share/man/man1/debconf-communicate.1.gz",
+            "/usr/share/man/man1/debconf-copydb.1.gz",
+            "/usr/share/man/man1/debconf-escape.1.gz",
+            "/usr/share/man/man1/debconf-set-selections.1.gz",
+            "/usr/share/man/man1/debconf-show.1.gz",
+            "/usr/share/man/man1/debconf.1.gz",
+            "/usr/share/man/man8/dpkg-preconfigure.8.gz",
+            "/usr/share/man/man8/dpkg-reconfigure.8.gz",
+            "/usr/share/perl5/Debconf/AutoSelect.pm",
+            "/usr/share/perl5/Debconf/Base.pm",
+            "/usr/share/perl5/Debconf/Client/ConfModule.pm",
+            "/usr/share/perl5/Debconf/ConfModule.pm",
+            "/usr/share/perl5/Debconf/Config.pm",
+            "/usr/share/perl5/Debconf/Db.pm",
+            "/usr/share/perl5/Debconf/DbDriver.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Backup.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Cache.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Copy.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Debug.pm",
+            "/usr/share/perl5/Debconf/DbDriver/DirTree.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Directory.pm",
+            "/usr/share/perl5/Debconf/DbDriver/File.pm",
+            "/usr/share/perl5/Debconf/DbDriver/LDAP.pm",
+            "/usr/share/perl5/Debconf/DbDriver/PackageDir.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Pipe.pm",
+            "/usr/share/perl5/Debconf/DbDriver/Stack.pm",
+            "/usr/share/perl5/Debconf/Element.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/String.pm",
+            "/usr/share/perl5/Debconf/Element/Dialog/Text.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/String.pm",
+            "/usr/share/perl5/Debconf/Element/Editor/Text.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/String.pm",
+            "/usr/share/perl5/Debconf/Element/Gnome/Text.pm",
+            "/usr/share/perl5/Debconf/Element/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/String.pm",
+            "/usr/share/perl5/Debconf/Element/Noninteractive/Text.pm",
+            "/usr/share/perl5/Debconf/Element/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/String.pm",
+            "/usr/share/perl5/Debconf/Element/Teletype/Text.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Boolean.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Error.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Multiselect.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Note.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Password.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Progress.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Select.pm",
+            "/usr/share/perl5/Debconf/Element/Web/String.pm",
+            "/usr/share/perl5/Debconf/Element/Web/Text.pm",
+            "/usr/share/perl5/Debconf/Encoding.pm",
+            "/usr/share/perl5/Debconf/Format.pm",
+            "/usr/share/perl5/Debconf/Format/822.pm",
+            "/usr/share/perl5/Debconf/FrontEnd.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Dialog.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Editor.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Gnome.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Kde.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Noninteractive.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Passthrough.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Readline.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/ScreenSize.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Teletype.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Text.pm",
+            "/usr/share/perl5/Debconf/FrontEnd/Web.pm",
+            "/usr/share/perl5/Debconf/Gettext.pm",
+            "/usr/share/perl5/Debconf/Iterator.pm",
+            "/usr/share/perl5/Debconf/Log.pm",
+            "/usr/share/perl5/Debconf/Path.pm",
+            "/usr/share/perl5/Debconf/Priority.pm",
+            "/usr/share/perl5/Debconf/Question.pm",
+            "/usr/share/perl5/Debconf/Template.pm",
+            "/usr/share/perl5/Debconf/Template/Transient.pm",
+            "/usr/share/perl5/Debconf/TmpFile.pm",
+            "/usr/share/perl5/Debian/DebConf/Client/ConfModule.pm",
+            "/usr/share/pixmaps/debian-logo.png"
+          ]
+        },
+        {
+          "ID": "debian-archive-keyring@2025.1",
+          "Name": "debian-archive-keyring",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/debian-archive-keyring@2025.1?arch=all\u0026distro=debian-13.1",
+            "UID": "3d23f3bc34b84a13"
+          },
+          "Version": "2025.1",
+          "Arch": "all",
+          "SrcName": "debian-archive-keyring",
+          "SrcVersion": "2025.1",
+          "Licenses": [
+            "GPL-2.0-or-later"
+          ],
+          "Maintainer": "Debian Release Team \u003cpackages@release.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/debian-archive-keyring/NEWS.Debian.gz",
+            "/usr/share/doc/debian-archive-keyring/README",
+            "/usr/share/doc/debian-archive-keyring/changelog.gz",
+            "/usr/share/doc/debian-archive-keyring/copyright",
+            "/usr/share/keyrings/debian-archive-bookworm-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-bookworm-security-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-bookworm-stable.pgp",
+            "/usr/share/keyrings/debian-archive-bullseye-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-bullseye-security-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-bullseye-stable.pgp",
+            "/usr/share/keyrings/debian-archive-keyring.pgp",
+            "/usr/share/keyrings/debian-archive-removed-keys.pgp",
+            "/usr/share/keyrings/debian-archive-trixie-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-trixie-security-automatic.pgp",
+            "/usr/share/keyrings/debian-archive-trixie-stable.pgp"
+          ]
+        },
+        {
+          "ID": "debianutils@5.23.2",
+          "Name": "debianutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/debianutils@5.23.2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1faaee83f4beb2af"
+          },
+          "Version": "5.23.2",
+          "Arch": "amd64",
+          "SrcName": "debianutils",
+          "SrcVersion": "5.23.2",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "public-domain",
+            "SMAIL-GPL"
+          ],
+          "Maintainer": "Ileana Dumitrescu \u003cileanadumitrescu95@gmail.com\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/ischroot",
+            "/usr/bin/run-parts",
+            "/usr/bin/savelog",
+            "/usr/bin/tempfile",
+            "/usr/bin/which.debianutils",
+            "/usr/sbin/add-shell",
+            "/usr/sbin/installkernel",
+            "/usr/sbin/remove-shell",
+            "/usr/sbin/update-shells",
+            "/usr/share/debianutils/shells",
+            "/usr/share/doc/debianutils/README.shells",
+            "/usr/share/doc/debianutils/changelog.gz",
+            "/usr/share/doc/debianutils/copyright",
+            "/usr/share/man/de/man1/which.debianutils.1.gz",
+            "/usr/share/man/de/man8/add-shell.8.gz",
+            "/usr/share/man/de/man8/installkernel.8.gz",
+            "/usr/share/man/de/man8/remove-shell.8.gz",
+            "/usr/share/man/de/man8/run-parts.8.gz",
+            "/usr/share/man/de/man8/savelog.8.gz",
+            "/usr/share/man/es/man1/which.debianutils.1.gz",
+            "/usr/share/man/es/man8/add-shell.8.gz",
+            "/usr/share/man/es/man8/installkernel.8.gz",
+            "/usr/share/man/es/man8/remove-shell.8.gz",
+            "/usr/share/man/es/man8/run-parts.8.gz",
+            "/usr/share/man/es/man8/savelog.8.gz",
+            "/usr/share/man/fr/man1/which.debianutils.1.gz",
+            "/usr/share/man/fr/man8/add-shell.8.gz",
+            "/usr/share/man/fr/man8/installkernel.8.gz",
+            "/usr/share/man/fr/man8/remove-shell.8.gz",
+            "/usr/share/man/fr/man8/run-parts.8.gz",
+            "/usr/share/man/fr/man8/savelog.8.gz",
+            "/usr/share/man/it/man1/which.debianutils.1.gz",
+            "/usr/share/man/it/man8/add-shell.8.gz",
+            "/usr/share/man/it/man8/installkernel.8.gz",
+            "/usr/share/man/it/man8/remove-shell.8.gz",
+            "/usr/share/man/it/man8/run-parts.8.gz",
+            "/usr/share/man/it/man8/savelog.8.gz",
+            "/usr/share/man/ja/man1/which.debianutils.1.gz",
+            "/usr/share/man/ja/man8/add-shell.8.gz",
+            "/usr/share/man/ja/man8/installkernel.8.gz",
+            "/usr/share/man/ja/man8/remove-shell.8.gz",
+            "/usr/share/man/ja/man8/run-parts.8.gz",
+            "/usr/share/man/ja/man8/savelog.8.gz",
+            "/usr/share/man/man1/ischroot.1.gz",
+            "/usr/share/man/man1/tempfile.1.gz",
+            "/usr/share/man/man1/which.debianutils.1.gz",
+            "/usr/share/man/man8/add-shell.8.gz",
+            "/usr/share/man/man8/installkernel.8.gz",
+            "/usr/share/man/man8/remove-shell.8.gz",
+            "/usr/share/man/man8/run-parts.8.gz",
+            "/usr/share/man/man8/savelog.8.gz",
+            "/usr/share/man/man8/update-shells.8.gz",
+            "/usr/share/man/pl/man1/which.debianutils.1.gz",
+            "/usr/share/man/pl/man8/add-shell.8.gz",
+            "/usr/share/man/pl/man8/installkernel.8.gz",
+            "/usr/share/man/pl/man8/remove-shell.8.gz",
+            "/usr/share/man/pl/man8/run-parts.8.gz",
+            "/usr/share/man/pl/man8/savelog.8.gz",
+            "/usr/share/man/pt/man1/which.debianutils.1.gz",
+            "/usr/share/man/pt/man8/add-shell.8.gz",
+            "/usr/share/man/pt/man8/installkernel.8.gz",
+            "/usr/share/man/pt/man8/remove-shell.8.gz",
+            "/usr/share/man/pt/man8/run-parts.8.gz",
+            "/usr/share/man/pt/man8/savelog.8.gz",
+            "/usr/share/man/sl/man1/which.debianutils.1.gz",
+            "/usr/share/man/sl/man8/add-shell.8.gz",
+            "/usr/share/man/sl/man8/installkernel.8.gz",
+            "/usr/share/man/sl/man8/remove-shell.8.gz",
+            "/usr/share/man/sl/man8/run-parts.8.gz",
+            "/usr/share/man/sl/man8/savelog.8.gz"
+          ]
+        },
+        {
+          "ID": "diffutils@1:3.10-4",
+          "Name": "diffutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/diffutils@3.10-4?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "6ae1b70a720e3ebb"
+          },
+          "Version": "3.10",
+          "Release": "4",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "diffutils",
+          "SrcVersion": "3.10",
+          "SrcRelease": "4",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "FSFULLR",
+            "LGPL-2.1-or-later",
+            "GPL-3.0-with-autoconf-exception+",
+            "GPL-3.0-only",
+            "GPL-3+ with texinfo exception",
+            "LGPL-2.0-or-later",
+            "GPL-2.0-or-later",
+            "X11",
+            "FSFAP",
+            "GFDL-1.3-no-invariants-only",
+            "LGPL-3.0-or-later",
+            "LGPL-3.0-only",
+            "public-domain",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "GPL-2.0-only",
+            "GFDL-1.3-only"
+          ],
+          "Maintainer": "Santiago Vila \u003csanvila@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/cmp",
+            "/usr/bin/diff",
+            "/usr/bin/diff3",
+            "/usr/bin/sdiff",
+            "/usr/share/doc/diffutils/NEWS.gz",
+            "/usr/share/doc/diffutils/changelog.Debian.gz",
+            "/usr/share/doc/diffutils/changelog.gz",
+            "/usr/share/doc/diffutils/copyright",
+            "/usr/share/info/diffutils.info.gz",
+            "/usr/share/locale/bg/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/da/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/de/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/el/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/es/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/he/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/id/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/it/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/lv/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/diffutils.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/diffutils.mo",
+            "/usr/share/man/man1/cmp.1.gz",
+            "/usr/share/man/man1/diff.1.gz",
+            "/usr/share/man/man1/diff3.1.gz",
+            "/usr/share/man/man1/sdiff.1.gz"
+          ]
+        },
+        {
+          "ID": "dpkg@1.22.21",
+          "Name": "dpkg",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/dpkg@1.22.21?arch=amd64\u0026distro=debian-13.1",
+            "UID": "cc27f3afd091dba3"
+          },
+          "Version": "1.22.21",
+          "Arch": "amd64",
+          "SrcName": "dpkg",
+          "SrcVersion": "1.22.21",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "public-domain-s-s-d",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Dpkg Developers \u003cdebian-dpkg@lists.debian.org\u003e",
+          "DependsOn": [
+            "tar@1.35+dfsg-3.1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/dpkg",
+            "/usr/bin/dpkg-deb",
+            "/usr/bin/dpkg-divert",
+            "/usr/bin/dpkg-maintscript-helper",
+            "/usr/bin/dpkg-query",
+            "/usr/bin/dpkg-realpath",
+            "/usr/bin/dpkg-split",
+            "/usr/bin/dpkg-statoverride",
+            "/usr/bin/dpkg-trigger",
+            "/usr/bin/update-alternatives",
+            "/usr/lib/systemd/system/dpkg-db-backup.service",
+            "/usr/lib/systemd/system/dpkg-db-backup.timer",
+            "/usr/libexec/dpkg/dpkg-db-backup",
+            "/usr/libexec/dpkg/dpkg-db-keeper",
+            "/usr/sbin/start-stop-daemon",
+            "/usr/share/doc/dpkg/AUTHORS",
+            "/usr/share/doc/dpkg/README.api",
+            "/usr/share/doc/dpkg/README.bug-usertags.gz",
+            "/usr/share/doc/dpkg/README.feature-removal-schedule.gz",
+            "/usr/share/doc/dpkg/THANKS.gz",
+            "/usr/share/doc/dpkg/changelog.gz",
+            "/usr/share/doc/dpkg/copyright",
+            "/usr/share/dpkg/abitable",
+            "/usr/share/dpkg/cputable",
+            "/usr/share/dpkg/ostable",
+            "/usr/share/dpkg/sh/dpkg-error.sh",
+            "/usr/share/dpkg/tupletable",
+            "/usr/share/lintian/overrides/dpkg",
+            "/usr/share/lintian/profiles/dpkg/main.profile",
+            "/usr/share/locale/ast/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/bs/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/da/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/de/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/dz/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/el/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/es/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/et/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/id/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/it/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/km/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ku/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/mr/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ne/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/nn/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/oc/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/pa/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/th/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/tl/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/dpkg.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/dpkg.mo",
+            "/usr/share/man/de/man1/dpkg-deb.1.gz",
+            "/usr/share/man/de/man1/dpkg-divert.1.gz",
+            "/usr/share/man/de/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/de/man1/dpkg-query.1.gz",
+            "/usr/share/man/de/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/de/man1/dpkg-split.1.gz",
+            "/usr/share/man/de/man1/dpkg-statoverride.1.gz",
+            "/usr/share/man/de/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/de/man1/dpkg.1.gz",
+            "/usr/share/man/de/man1/update-alternatives.1.gz",
+            "/usr/share/man/de/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/de/man8/start-stop-daemon.8.gz",
+            "/usr/share/man/es/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/fr/man1/dpkg-divert.1.gz",
+            "/usr/share/man/fr/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/fr/man1/dpkg-query.1.gz",
+            "/usr/share/man/fr/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/fr/man1/dpkg-split.1.gz",
+            "/usr/share/man/fr/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/fr/man1/update-alternatives.1.gz",
+            "/usr/share/man/fr/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/fr/man8/start-stop-daemon.8.gz",
+            "/usr/share/man/it/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/ja/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/man1/dpkg-deb.1.gz",
+            "/usr/share/man/man1/dpkg-divert.1.gz",
+            "/usr/share/man/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/man1/dpkg-query.1.gz",
+            "/usr/share/man/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/man1/dpkg-split.1.gz",
+            "/usr/share/man/man1/dpkg-statoverride.1.gz",
+            "/usr/share/man/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/man1/dpkg.1.gz",
+            "/usr/share/man/man1/update-alternatives.1.gz",
+            "/usr/share/man/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/man8/start-stop-daemon.8.gz",
+            "/usr/share/man/nl/man1/dpkg-deb.1.gz",
+            "/usr/share/man/nl/man1/dpkg-divert.1.gz",
+            "/usr/share/man/nl/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/nl/man1/dpkg-query.1.gz",
+            "/usr/share/man/nl/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/nl/man1/dpkg-split.1.gz",
+            "/usr/share/man/nl/man1/dpkg-statoverride.1.gz",
+            "/usr/share/man/nl/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/nl/man1/dpkg.1.gz",
+            "/usr/share/man/nl/man1/update-alternatives.1.gz",
+            "/usr/share/man/nl/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/nl/man8/start-stop-daemon.8.gz",
+            "/usr/share/man/pl/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/pt/man1/dpkg-deb.1.gz",
+            "/usr/share/man/pt/man1/dpkg-divert.1.gz",
+            "/usr/share/man/pt/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/pt/man1/dpkg-query.1.gz",
+            "/usr/share/man/pt/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/pt/man1/dpkg-split.1.gz",
+            "/usr/share/man/pt/man1/dpkg-statoverride.1.gz",
+            "/usr/share/man/pt/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/pt/man1/dpkg.1.gz",
+            "/usr/share/man/pt/man1/update-alternatives.1.gz",
+            "/usr/share/man/pt/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/pt/man8/start-stop-daemon.8.gz",
+            "/usr/share/man/sv/man1/dpkg-deb.1.gz",
+            "/usr/share/man/sv/man1/dpkg-divert.1.gz",
+            "/usr/share/man/sv/man1/dpkg-maintscript-helper.1.gz",
+            "/usr/share/man/sv/man1/dpkg-query.1.gz",
+            "/usr/share/man/sv/man1/dpkg-realpath.1.gz",
+            "/usr/share/man/sv/man1/dpkg-split.1.gz",
+            "/usr/share/man/sv/man1/dpkg-statoverride.1.gz",
+            "/usr/share/man/sv/man1/dpkg-trigger.1.gz",
+            "/usr/share/man/sv/man1/dpkg.1.gz",
+            "/usr/share/man/sv/man1/update-alternatives.1.gz",
+            "/usr/share/man/sv/man5/dpkg.cfg.5.gz",
+            "/usr/share/man/sv/man8/start-stop-daemon.8.gz",
+            "/usr/share/polkit-1/actions/org.dpkg.pkexec.update-alternatives.policy"
+          ]
+        },
+        {
+          "ID": "findutils@4.10.0-3",
+          "Name": "findutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/findutils@4.10.0-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "111949a4800741f1"
+          },
+          "Version": "4.10.0",
+          "Release": "3",
+          "Arch": "amd64",
+          "SrcName": "findutils",
+          "SrcVersion": "4.10.0",
+          "SrcRelease": "3",
+          "Licenses": [
+            "GFDL-1.3-no-invariants-or-later",
+            "GPL-3.0-or-later",
+            "FSFAP",
+            "GPL-2+ with Autoconf-data exception",
+            "GPL-3+ with Autoconf-data exception",
+            "FSFULLR",
+            "GPL-2.0-or-later",
+            "X11",
+            "public-domain",
+            "LGPL-2.1-or-later",
+            "GPL with automake exception",
+            "LGPL-2.0-or-later",
+            "LGPL-3.0-or-later",
+            "BSD-3-Clause",
+            "GPL-3+ with Bison-2.2 exception",
+            "LGPL-3.0-only",
+            "ISC",
+            "GFDL-1.3-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Andreas Metzler \u003cametzler@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/find",
+            "/usr/bin/xargs",
+            "/usr/share/doc-base/findutils.findutils",
+            "/usr/share/doc/findutils/NEWS.gz",
+            "/usr/share/doc/findutils/README.gz",
+            "/usr/share/doc/findutils/TODO",
+            "/usr/share/doc/findutils/changelog.Debian.gz",
+            "/usr/share/doc/findutils/changelog.gz",
+            "/usr/share/doc/findutils/copyright",
+            "/usr/share/info/find-maint.info.gz",
+            "/usr/share/info/find.info.gz",
+            "/usr/share/locale/be/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/da/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/de/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/el/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/es/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/et/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/id/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/it/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/lg/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/findutils.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/findutils.mo",
+            "/usr/share/man/man1/find.1.gz",
+            "/usr/share/man/man1/xargs.1.gz"
+          ]
+        },
+        {
+          "ID": "gcc-14-base@14.2.0-19",
+          "Name": "gcc-14-base",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/gcc-14-base@14.2.0-19?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a2d64c6b5f038075"
+          },
+          "Version": "14.2.0",
+          "Release": "19",
+          "Arch": "amd64",
+          "SrcName": "gcc-14",
+          "SrcVersion": "14.2.0",
+          "SrcRelease": "19",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-3.0-only",
+            "GFDL-1.2-only",
+            "Artistic-2.0",
+            "LGPL-2.0-or-later"
+          ],
+          "Maintainer": "Debian GCC Maintainers \u003cdebian-gcc@lists.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/gcc-14-base/README.Debian.amd64.gz",
+            "/usr/share/doc/gcc-14-base/TODO.Debian",
+            "/usr/share/doc/gcc-14-base/changelog.Debian.gz",
+            "/usr/share/doc/gcc-14-base/copyright"
+          ]
+        },
+        {
+          "ID": "grep@3.11-4",
+          "Name": "grep",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/grep@3.11-4?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d450e0ea7fae458f"
+          },
+          "Version": "3.11",
+          "Release": "4",
+          "Arch": "amd64",
+          "SrcName": "grep",
+          "SrcVersion": "3.11",
+          "SrcRelease": "4",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Anibal Monsalve Salazar \u003canibal@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/egrep",
+            "/usr/bin/fgrep",
+            "/usr/bin/grep",
+            "/usr/bin/rgrep",
+            "/usr/share/doc/grep/AUTHORS",
+            "/usr/share/doc/grep/NEWS.Debian.gz",
+            "/usr/share/doc/grep/NEWS.gz",
+            "/usr/share/doc/grep/README",
+            "/usr/share/doc/grep/THANKS.gz",
+            "/usr/share/doc/grep/TODO.gz",
+            "/usr/share/doc/grep/changelog.Debian.gz",
+            "/usr/share/doc/grep/changelog.gz",
+            "/usr/share/doc/grep/copyright",
+            "/usr/share/info/grep.info.gz",
+            "/usr/share/locale/af/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/be/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/da/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/de/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/el/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/es/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/et/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/he/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/id/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/it/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ky/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/pa/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/ta/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/th/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/grep.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/grep.mo",
+            "/usr/share/man/man1/grep.1.gz"
+          ]
+        },
+        {
+          "ID": "gzip@1.13-1",
+          "Name": "gzip",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/gzip@1.13-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "60254b2bea6a1f09"
+          },
+          "Version": "1.13",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "gzip",
+          "SrcVersion": "1.13",
+          "SrcRelease": "1",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GFDL-1.3+-no-invariant",
+            "FSF-manpages",
+            "GPL-3.0-only",
+            "GFDL-3"
+          ],
+          "Maintainer": "Milan Kupcevic \u003cmilan@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/gunzip",
+            "/usr/bin/gzexe",
+            "/usr/bin/gzip",
+            "/usr/bin/zcat",
+            "/usr/bin/zcmp",
+            "/usr/bin/zdiff",
+            "/usr/bin/zegrep",
+            "/usr/bin/zfgrep",
+            "/usr/bin/zforce",
+            "/usr/bin/zgrep",
+            "/usr/bin/zless",
+            "/usr/bin/zmore",
+            "/usr/bin/znew",
+            "/usr/share/doc/gzip/NEWS.gz",
+            "/usr/share/doc/gzip/README.gz",
+            "/usr/share/doc/gzip/TODO",
+            "/usr/share/doc/gzip/changelog.Debian.gz",
+            "/usr/share/doc/gzip/changelog.gz",
+            "/usr/share/doc/gzip/copyright",
+            "/usr/share/info/gzip.info.gz",
+            "/usr/share/man/man1/gzexe.1.gz",
+            "/usr/share/man/man1/gzip.1.gz",
+            "/usr/share/man/man1/zdiff.1.gz",
+            "/usr/share/man/man1/zforce.1.gz",
+            "/usr/share/man/man1/zgrep.1.gz",
+            "/usr/share/man/man1/zless.1.gz",
+            "/usr/share/man/man1/zmore.1.gz",
+            "/usr/share/man/man1/znew.1.gz"
+          ]
+        },
+        {
+          "ID": "hostname@3.25",
+          "Name": "hostname",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/hostname@3.25?arch=amd64\u0026distro=debian-13.1",
+            "UID": "87ef62957d44b2c"
+          },
+          "Version": "3.25",
+          "Arch": "amd64",
+          "SrcName": "hostname",
+          "SrcVersion": "3.25",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Michael Meskes \u003cmeskes@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/hostname",
+            "/usr/share/doc/hostname/changelog.gz",
+            "/usr/share/doc/hostname/copyright",
+            "/usr/share/man/man1/hostname.1.gz"
+          ]
+        },
+        {
+          "ID": "init-system-helpers@1.69~deb13u1",
+          "Name": "init-system-helpers",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/init-system-helpers@1.69~deb13u1?arch=all\u0026distro=debian-13.1",
+            "UID": "317be9d9c6744acd"
+          },
+          "Version": "1.69~deb13u1",
+          "Arch": "all",
+          "SrcName": "init-system-helpers",
+          "SrcVersion": "1.69~deb13u1",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian systemd Maintainers \u003cpkg-systemd-maintainers@lists.alioth.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/deb-systemd-helper",
+            "/usr/bin/deb-systemd-invoke",
+            "/usr/sbin/invoke-rc.d",
+            "/usr/sbin/service",
+            "/usr/sbin/update-rc.d",
+            "/usr/share/bug/init-system-helpers/control",
+            "/usr/share/doc/init-system-helpers/README.invoke-rc.d.gz",
+            "/usr/share/doc/init-system-helpers/README.policy-rc.d.gz",
+            "/usr/share/doc/init-system-helpers/changelog.gz",
+            "/usr/share/doc/init-system-helpers/copyright",
+            "/usr/share/lintian/overrides/init-system-helpers",
+            "/usr/share/man/man1/deb-systemd-helper.1p.gz",
+            "/usr/share/man/man1/deb-systemd-invoke.1p.gz",
+            "/usr/share/man/man8/invoke-rc.d.8.gz",
+            "/usr/share/man/man8/service.8.gz",
+            "/usr/share/man/man8/update-rc.d.8.gz"
+          ]
+        },
+        {
+          "ID": "krb5-locales@1.21.3-5",
+          "Name": "krb5-locales",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/krb5-locales@1.21.3-5?arch=all\u0026distro=debian-13.1",
+            "UID": "e9e09fdd7f36416e"
+          },
+          "Version": "1.21.3",
+          "Release": "5",
+          "Arch": "all",
+          "SrcName": "krb5",
+          "SrcVersion": "1.21.3",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/krb5-locales/changelog.Debian.gz",
+            "/usr/share/doc/krb5-locales/copyright",
+            "/usr/share/locale/de/LC_MESSAGES/mit-krb5.mo",
+            "/usr/share/locale/en_US/LC_MESSAGES/mit-krb5.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/mit-krb5.mo"
+          ]
+        },
+        {
+          "ID": "libacl1@2.3.2-2+b1",
+          "Name": "libacl1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libacl1@2.3.2-2%2Bb1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c595e244e31bea2f"
+          },
+          "Version": "2.3.2",
+          "Release": "2+b1",
+          "Arch": "amd64",
+          "SrcName": "acl",
+          "SrcVersion": "2.3.2",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "LGPL-2.0-or-later",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Guillem Jover \u003cguillem@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libacl.so.1.1.2302",
+            "/usr/share/doc/libacl1/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libacl1/changelog.Debian.gz",
+            "/usr/share/doc/libacl1/changelog.gz",
+            "/usr/share/doc/libacl1/copyright",
+            "/usr/share/lintian/overrides/libacl1"
+          ]
+        },
+        {
+          "ID": "libapt-pkg7.0@3.0.3",
+          "Name": "libapt-pkg7.0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libapt-pkg7.0@3.0.3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "80dd2636db3e0564"
+          },
+          "Version": "3.0.3",
+          "Arch": "amd64",
+          "SrcName": "apt",
+          "SrcVersion": "3.0.3",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "curl",
+            "BSD-3-Clause",
+            "MIT",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "APT Development Team \u003cdeity@lists.debian.org\u003e",
+          "DependsOn": [
+            "libbz2-1.0@1.0.8-6",
+            "libc6@2.41-12",
+            "libgcc-s1@14.2.0-19",
+            "liblz4-1@1.10.0-4",
+            "liblzma5@5.8.1-1",
+            "libssl3t64@3.5.1-1+deb13u1",
+            "libstdc++6@14.2.0-19",
+            "libsystemd0@257.8-1~deb13u2",
+            "libudev1@257.8-1~deb13u2",
+            "libxxhash0@0.8.3-2",
+            "libzstd1@1.5.7+dfsg-1",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libapt-pkg.so.7.0.0",
+            "/usr/share/doc/libapt-pkg7.0/NEWS.Debian.gz",
+            "/usr/share/doc/libapt-pkg7.0/changelog.gz",
+            "/usr/share/doc/libapt-pkg7.0/copyright",
+            "/usr/share/locale/ar/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ast/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/bs/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/cy/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/da/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/de/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/dz/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/el/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/es/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/it/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/km/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ku/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/mr/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ne/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/nn/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/th/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/tl/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/libapt-pkg7.0.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/libapt-pkg7.0.mo"
+          ]
+        },
+        {
+          "ID": "libattr1@1:2.5.2-3",
+          "Name": "libattr1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libattr1@2.5.2-3?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "6e85fd1e20e432a1"
+          },
+          "Version": "2.5.2",
+          "Release": "3",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "attr",
+          "SrcVersion": "2.5.2",
+          "SrcRelease": "3",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "LGPL-2.0-or-later",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Guillem Jover \u003cguillem@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libattr.so.1.1.2502",
+            "/usr/share/doc/libattr1/changelog.Debian.gz",
+            "/usr/share/doc/libattr1/changelog.gz",
+            "/usr/share/doc/libattr1/copyright",
+            "/usr/share/lintian/overrides/libattr1"
+          ]
+        },
+        {
+          "ID": "libaudit-common@1:4.0.2-2",
+          "Name": "libaudit-common",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libaudit-common@4.0.2-2?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "4845289e49197cbd"
+          },
+          "Version": "4.0.2",
+          "Release": "2",
+          "Epoch": 1,
+          "Arch": "all",
+          "SrcName": "audit",
+          "SrcVersion": "4.0.2",
+          "SrcRelease": "2",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "GPL-2.0-only",
+            "LGPL-2.1-only",
+            "GPL-1.0-only"
+          ],
+          "Maintainer": "Laurent Bigonville \u003cbigon@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/libaudit-common/changelog.Debian.gz",
+            "/usr/share/doc/libaudit-common/changelog.gz",
+            "/usr/share/doc/libaudit-common/copyright",
+            "/usr/share/man/man5/libaudit.conf.5.gz"
+          ]
+        },
+        {
+          "ID": "libaudit1@1:4.0.2-2+b2",
+          "Name": "libaudit1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libaudit1@4.0.2-2%2Bb2?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "60f29d52a96eceff"
+          },
+          "Version": "4.0.2",
+          "Release": "2+b2",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "audit",
+          "SrcVersion": "4.0.2",
+          "SrcRelease": "2",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "GPL-2.0-only",
+            "LGPL-2.1-only",
+            "GPL-1.0-only"
+          ],
+          "Maintainer": "Laurent Bigonville \u003cbigon@debian.org\u003e",
+          "DependsOn": [
+            "libaudit-common@1:4.0.2-2",
+            "libc6@2.41-12",
+            "libcap-ng0@0.8.5-4+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libaudit.so.1.0.0",
+            "/usr/share/doc/libaudit1/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libaudit1/changelog.Debian.gz",
+            "/usr/share/doc/libaudit1/changelog.gz",
+            "/usr/share/doc/libaudit1/copyright"
+          ]
+        },
+        {
+          "ID": "libblkid1@2.41-5",
+          "Name": "libblkid1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libblkid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6c9693ac78293e63"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0",
+            "/usr/share/doc/libblkid1/NEWS.Debian.gz",
+            "/usr/share/doc/libblkid1/changelog.Debian.gz",
+            "/usr/share/doc/libblkid1/changelog.gz",
+            "/usr/share/doc/libblkid1/copyright",
+            "/usr/share/lintian/overrides/libblkid1"
+          ]
+        },
+        {
+          "ID": "libbrotli1@1.1.0-2+b7",
+          "Name": "libbrotli1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libbrotli1@1.1.0-2%2Bb7?arch=amd64\u0026distro=debian-13.1",
+            "UID": "83a47ba58346a303"
+          },
+          "Version": "1.1.0",
+          "Release": "2+b7",
+          "Arch": "amd64",
+          "SrcName": "brotli",
+          "SrcVersion": "1.1.0",
+          "SrcRelease": "2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Maintainer": "Tomasz Buchert \u003ctomasz@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0",
+            "/usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0",
+            "/usr/lib/x86_64-linux-gnu/libbrotlienc.so.1.1.0",
+            "/usr/share/doc/libbrotli1/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libbrotli1/changelog.Debian.gz",
+            "/usr/share/doc/libbrotli1/changelog.gz",
+            "/usr/share/doc/libbrotli1/copyright",
+            "/usr/share/lintian/overrides/libbrotli1"
+          ]
+        },
+        {
+          "ID": "libbsd0@0.12.2-2",
+          "Name": "libbsd0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libbsd0@0.12.2-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b5c78e91ff2e46a4"
+          },
+          "Version": "0.12.2",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libbsd",
+          "SrcVersion": "0.12.2",
+          "SrcRelease": "2",
+          "Licenses": [
+            "BSD-3-Clause",
+            "BSD-3-clause-Regents",
+            "BSD-2-Clause-NetBSD",
+            "BSD-3-clause-author",
+            "BSD-3-clause-John-Birrell",
+            "BSD-5-clause-Peter-Wemm",
+            "BSD-2-Clause",
+            "BSD-2-clause-verbatim",
+            "BSD-2-clause-author",
+            "ISC",
+            "ISC-Original",
+            "MIT",
+            "public-domain",
+            "Beerware"
+          ],
+          "Maintainer": "Guillem Jover \u003cguillem@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libmd0@1.1.0-2+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libbsd.so.0.12.2",
+            "/usr/share/doc/libbsd0/changelog.Debian.gz",
+            "/usr/share/doc/libbsd0/changelog.gz",
+            "/usr/share/doc/libbsd0/copyright",
+            "/usr/share/lintian/overrides/libbsd0"
+          ]
+        },
+        {
+          "ID": "libbz2-1.0@1.0.8-6",
+          "Name": "libbz2-1.0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libbz2-1.0@1.0.8-6?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6fdb2eb525b1d46"
+          },
+          "Version": "1.0.8",
+          "Release": "6",
+          "Arch": "amd64",
+          "SrcName": "bzip2",
+          "SrcVersion": "1.0.8",
+          "SrcRelease": "6",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Anibal Monsalve Salazar \u003canibal@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libbz2.so.1.0.4",
+            "/usr/share/doc/libbz2-1.0/changelog.Debian.gz",
+            "/usr/share/doc/libbz2-1.0/changelog.gz",
+            "/usr/share/doc/libbz2-1.0/copyright"
+          ]
+        },
+        {
+          "ID": "libc-bin@2.41-12",
+          "Name": "libc-bin",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "Version": "2.41",
+          "Release": "12",
+          "Arch": "amd64",
+          "SrcName": "glibc",
+          "SrcVersion": "2.41",
+          "SrcRelease": "12",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "LGPL-2.0-or-later",
+            "LGPL-2.1+-with-link-exception",
+            "LGPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "GPL-2+-with-link-exception",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "FSFAP",
+            "Carnegie",
+            "Inner-Net",
+            "MIT-like-Lord",
+            "BSD-like-Spencer",
+            "PCRE",
+            "BSD-3-clause-Carnegie",
+            "Unicode-DFS-2016",
+            "BSL-1.0",
+            "SunPro",
+            "CORE-MATH",
+            "BSD-3-clause-Berkeley",
+            "BSD-3-clause-WIDE",
+            "BSD-2-Clause",
+            "BSD-3-clause-Oracle",
+            "DEC",
+            "IBM",
+            "ISC",
+            "Univ-Coimbra",
+            "public-domain",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "GNU Libc Maintainers \u003cdebian-glibc@lists.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/getconf",
+            "/usr/bin/getent",
+            "/usr/bin/iconv",
+            "/usr/bin/ldd",
+            "/usr/bin/locale",
+            "/usr/bin/localedef",
+            "/usr/bin/pldd",
+            "/usr/bin/tzselect",
+            "/usr/bin/zdump",
+            "/usr/lib/locale/C.utf8/LC_ADDRESS",
+            "/usr/lib/locale/C.utf8/LC_COLLATE",
+            "/usr/lib/locale/C.utf8/LC_CTYPE",
+            "/usr/lib/locale/C.utf8/LC_IDENTIFICATION",
+            "/usr/lib/locale/C.utf8/LC_MEASUREMENT",
+            "/usr/lib/locale/C.utf8/LC_MESSAGES/SYS_LC_MESSAGES",
+            "/usr/lib/locale/C.utf8/LC_MONETARY",
+            "/usr/lib/locale/C.utf8/LC_NAME",
+            "/usr/lib/locale/C.utf8/LC_NUMERIC",
+            "/usr/lib/locale/C.utf8/LC_PAPER",
+            "/usr/lib/locale/C.utf8/LC_TELEPHONE",
+            "/usr/lib/locale/C.utf8/LC_TIME",
+            "/usr/sbin/iconvconfig",
+            "/usr/sbin/ldconfig",
+            "/usr/sbin/zic",
+            "/usr/share/doc/libc-bin/changelog.Debian.gz",
+            "/usr/share/doc/libc-bin/changelog.gz",
+            "/usr/share/doc/libc-bin/copyright",
+            "/usr/share/libc-bin/nsswitch.conf",
+            "/usr/share/lintian/overrides/libc-bin",
+            "/usr/share/man/man1/getconf.1.gz",
+            "/usr/share/man/man1/tzselect.1.gz"
+          ]
+        },
+        {
+          "ID": "libc6@2.41-12",
+          "Name": "libc6",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "Version": "2.41",
+          "Release": "12",
+          "Arch": "amd64",
+          "SrcName": "glibc",
+          "SrcVersion": "2.41",
+          "SrcRelease": "12",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "LGPL-2.0-or-later",
+            "LGPL-2.1+-with-link-exception",
+            "LGPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "GPL-2+-with-link-exception",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "FSFAP",
+            "Carnegie",
+            "Inner-Net",
+            "MIT-like-Lord",
+            "BSD-like-Spencer",
+            "PCRE",
+            "BSD-3-clause-Carnegie",
+            "Unicode-DFS-2016",
+            "BSL-1.0",
+            "SunPro",
+            "CORE-MATH",
+            "BSD-3-clause-Berkeley",
+            "BSD-3-clause-WIDE",
+            "BSD-2-Clause",
+            "BSD-3-clause-Oracle",
+            "DEC",
+            "IBM",
+            "ISC",
+            "Univ-Coimbra",
+            "public-domain",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "GNU Libc Maintainers \u003cdebian-glibc@lists.debian.org\u003e",
+          "DependsOn": [
+            "libgcc-s1@14.2.0-19"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/gconv/ANSI_X3.110.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ARMSCII-8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ASMO_449.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/BIG5.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/BIG5HKSCS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/BRF.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP10007.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1125.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1250.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1251.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1252.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1253.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1254.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1255.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1256.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1257.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP1258.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP737.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP770.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP771.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP772.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP773.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP774.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP775.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CP932.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CSN_369103.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/CWI.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/DEC-MCS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-AT-DE-A.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-AT-DE.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-CA-FR.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-DK-NO-A.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-DK-NO.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-ES-A.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-ES-S.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-ES.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-FI-SE-A.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-FI-SE.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-FR.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-IS-FRISS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-IT.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-PT.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-UK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EBCDIC-US.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ECMA-CYRILLIC.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-CN.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-JISX0213.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-JP-MS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-JP.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-KR.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/EUC-TW.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GB18030.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GBBIG5.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GBGBK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GBK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GEORGIAN-ACADEMY.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GEORGIAN-PS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GOST_19768-74.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GREEK-CCITT.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GREEK7-OLD.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/GREEK7.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/HP-GREEK8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/HP-ROMAN8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/HP-ROMAN9.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/HP-THAI8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/HP-TURKISH8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM037.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM038.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1004.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1008.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1008_420.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1025.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1026.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1046.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1047.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1097.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1112.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1122.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1123.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1124.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1129.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1130.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1132.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1133.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1137.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1140.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1141.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1142.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1143.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1144.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1145.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1146.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1147.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1148.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1149.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1153.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1154.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1155.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1156.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1157.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1158.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1160.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1161.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1162.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1163.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1164.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1166.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1167.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM12712.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1364.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1371.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1388.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1390.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM1399.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM16804.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM256.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM273.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM274.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM275.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM277.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM278.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM280.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM281.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM284.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM285.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM290.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM297.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM420.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM423.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM424.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM437.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM4517.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM4899.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM4909.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM4971.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM500.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM5347.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM803.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM850.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM851.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM852.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM855.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM856.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM857.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM858.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM860.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM861.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM862.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM863.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM864.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM865.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM866.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM866NAV.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM868.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM869.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM870.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM871.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM874.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM875.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM880.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM891.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM901.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM902.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM903.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM9030.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM904.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM905.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM9066.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM918.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM921.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM922.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM930.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM932.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM933.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM935.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM937.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM939.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM943.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IBM9448.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/IEC_P27-1.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/INIS-8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/INIS-CYRILLIC.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/INIS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISIRI-3342.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-2022-CN-EXT.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-2022-CN.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-2022-JP-3.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-2022-JP.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-2022-KR.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-IR-197.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO-IR-209.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO646.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-1.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-10.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-11.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-13.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-14.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-15.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-16.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-2.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-3.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-4.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-5.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-6.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-7.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-9.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO8859-9E.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_10367-BOX.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_11548-1.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_2033.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_5427-EXT.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_5427.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_5428.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_6937-2.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/ISO_6937.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/JOHAB.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/KOI-8.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/KOI8-R.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/KOI8-RU.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/KOI8-T.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/KOI8-U.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/LATIN-GREEK-1.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/LATIN-GREEK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MAC-CENTRALEUROPE.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MAC-IS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MAC-SAMI.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MAC-UK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MACINTOSH.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/MIK.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/NATS-DANO.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/NATS-SEFI.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/PT154.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/RK1048.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/SAMI-WS2.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/SHIFT_JISX0213.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/SJIS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/T.61.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/TCVN5712-1.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/TIS-620.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/TSCII.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/UHC.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/UNICODE.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/UTF-16.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/UTF-32.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/UTF-7.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/VISCII.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/gconv-modules",
+            "/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache",
+            "/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.d/gconv-modules-extra.conf",
+            "/usr/lib/x86_64-linux-gnu/gconv/libCNS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/libGB.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/libISOIR165.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/libJIS.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/libJISX0213.so",
+            "/usr/lib/x86_64-linux-gnu/gconv/libKSC.so",
+            "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
+            "/usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1",
+            "/usr/lib/x86_64-linux-gnu/libanl.so.1",
+            "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            "/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0",
+            "/usr/lib/x86_64-linux-gnu/libdl.so.2",
+            "/usr/lib/x86_64-linux-gnu/libm.so.6",
+            "/usr/lib/x86_64-linux-gnu/libmemusage.so",
+            "/usr/lib/x86_64-linux-gnu/libmvec.so.1",
+            "/usr/lib/x86_64-linux-gnu/libnsl.so.1",
+            "/usr/lib/x86_64-linux-gnu/libnss_compat.so.2",
+            "/usr/lib/x86_64-linux-gnu/libnss_dns.so.2",
+            "/usr/lib/x86_64-linux-gnu/libnss_files.so.2",
+            "/usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2",
+            "/usr/lib/x86_64-linux-gnu/libpcprofile.so",
+            "/usr/lib/x86_64-linux-gnu/libpthread.so.0",
+            "/usr/lib/x86_64-linux-gnu/libresolv.so.2",
+            "/usr/lib/x86_64-linux-gnu/librt.so.1",
+            "/usr/lib/x86_64-linux-gnu/libthread_db.so.1",
+            "/usr/lib/x86_64-linux-gnu/libutil.so.1",
+            "/usr/share/doc/libc6/NEWS.Debian.gz",
+            "/usr/share/doc/libc6/NEWS.gz",
+            "/usr/share/doc/libc6/README.Debian.gz",
+            "/usr/share/doc/libc6/README.hesiod.gz",
+            "/usr/share/doc/libc6/changelog.Debian.gz",
+            "/usr/share/doc/libc6/changelog.gz",
+            "/usr/share/doc/libc6/copyright",
+            "/usr/share/lintian/overrides/libc6"
+          ]
+        },
+        {
+          "ID": "libcap-ng0@0.8.5-4+b1",
+          "Name": "libcap-ng0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libcap-ng0@0.8.5-4%2Bb1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ca9cbd06f9ca5e4"
+          },
+          "Version": "0.8.5",
+          "Release": "4+b1",
+          "Arch": "amd64",
+          "SrcName": "libcap-ng",
+          "SrcVersion": "0.8.5",
+          "SrcRelease": "4",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "GPL-2.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.1-only",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Håvard F. Aasen \u003chavard.f.aasen@pfft.no\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libcap-ng.so.0.0.0",
+            "/usr/lib/x86_64-linux-gnu/libdrop_ambient.so.0.0.0",
+            "/usr/share/doc/libcap-ng0/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libcap-ng0/changelog.Debian.gz",
+            "/usr/share/doc/libcap-ng0/changelog.gz",
+            "/usr/share/doc/libcap-ng0/copyright"
+          ]
+        },
+        {
+          "ID": "libcap2@1:2.75-10+b1",
+          "Name": "libcap2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libcap2@2.75-10%2Bb1?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "53ebb813a3a7b3ac"
+          },
+          "Version": "2.75",
+          "Release": "10+b1",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "libcap2",
+          "SrcVersion": "2.75",
+          "SrcRelease": "10",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-only",
+            "GPL-2.0-or-later"
+          ],
+          "Maintainer": "Christian Kastner \u003cckk@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libcap.so.2.75",
+            "/usr/lib/x86_64-linux-gnu/libpsx.so.2.75",
+            "/usr/share/doc/libcap2/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libcap2/changelog.Debian.gz",
+            "/usr/share/doc/libcap2/changelog.gz",
+            "/usr/share/doc/libcap2/copyright"
+          ]
+        },
+        {
+          "ID": "libcom-err2@1.47.2-3+b3",
+          "Name": "libcom-err2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libcom-err2@1.47.2-3%2Bb3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7170974bb2239ef5"
+          },
+          "Version": "1.47.2",
+          "Release": "3+b3",
+          "Arch": "amd64",
+          "SrcName": "e2fsprogs",
+          "SrcVersion": "1.47.2",
+          "SrcRelease": "3",
+          "Licenses": [
+            "GPL-2.0-only",
+            "GPL-2.0-or-later",
+            "0BSD",
+            "MIT",
+            "BSD-3-Clause-Variant",
+            "BSD-3-Clause",
+            "BSD-4-Clause-CMU",
+            "LGPL-2.0-only",
+            "Apache-2.0",
+            "ISC",
+            "MIT-US-export",
+            "Kazlib",
+            "Latex2e",
+            "GPL-2+ with Texinfo exception"
+          ],
+          "Maintainer": "Theodore Y. Ts'o \u003ctytso@mit.edu\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1",
+            "/usr/share/doc/libcom-err2/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libcom-err2/changelog.Debian.gz",
+            "/usr/share/doc/libcom-err2/copyright"
+          ]
+        },
+        {
+          "ID": "libcrypt1@1:4.4.38-1",
+          "Name": "libcrypt1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libcrypt1@4.4.38-1?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "fca8f76663a33f72"
+          },
+          "Version": "4.4.38",
+          "Release": "1",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "libxcrypt",
+          "SrcVersion": "4.4.38",
+          "SrcRelease": "1",
+          "SrcEpoch": 1,
+          "Maintainer": "Marco d'Itri \u003cmd@linux.it\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0",
+            "/usr/share/doc/libcrypt1/changelog.Debian.gz",
+            "/usr/share/doc/libcrypt1/changelog.gz",
+            "/usr/share/doc/libcrypt1/copyright"
+          ]
+        },
+        {
+          "ID": "libcurl4t64@8.14.1-2+deb13u2",
+          "Name": "libcurl4t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libcurl4t64@8.14.1-2%2Bdeb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "cfaf3021b0fcfb8f"
+          },
+          "Version": "8.14.1",
+          "Release": "2+deb13u2",
+          "Arch": "amd64",
+          "SrcName": "curl",
+          "SrcVersion": "8.14.1",
+          "SrcRelease": "2+deb13u2",
+          "Licenses": [
+            "curl",
+            "OLDAP-2.8",
+            "ISC",
+            "GPL-2+ with Autoconf-data exception",
+            "GPL-3+ with Autoconf-data exception",
+            "GPL-2+ with Libtool exception",
+            "BSD-3-Clause",
+            "BSD-4-Clause-UC",
+            "FSFULLR",
+            "X11",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian Curl Maintainers \u003cteam+curl@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libbrotli1@1.1.0-2+b7",
+            "libc6@2.41-12",
+            "libgssapi-krb5-2@1.21.3-5",
+            "libidn2-0@2.3.8-2",
+            "libldap2@2.6.10+dfsg-1",
+            "libnghttp2-14@1.64.0-1.1",
+            "libnghttp3-9@1.8.0-1",
+            "libpsl5t64@0.21.2-1.1+b1",
+            "librtmp1@2.4+20151223.gitfa8646d.1-2+b5",
+            "libssh2-1t64@1.11.1-1",
+            "libssl3t64@3.5.1-1+deb13u1",
+            "libzstd1@1.5.7+dfsg-1",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libcurl.so.4.8.0",
+            "/usr/share/doc/libcurl4t64/changelog.Debian.gz",
+            "/usr/share/doc/libcurl4t64/changelog.gz",
+            "/usr/share/doc/libcurl4t64/copyright"
+          ]
+        },
+        {
+          "ID": "libdb5.3t64@5.3.28+dfsg2-9",
+          "Name": "libdb5.3t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libdb5.3t64@5.3.28%2Bdfsg2-9?arch=amd64\u0026distro=debian-13.1",
+            "UID": "53e4de325e6240d4"
+          },
+          "Version": "5.3.28+dfsg2",
+          "Release": "9",
+          "Arch": "amd64",
+          "SrcName": "db5.3",
+          "SrcVersion": "5.3.28+dfsg2",
+          "SrcRelease": "9",
+          "Licenses": [
+            "Sleepycat",
+            "BSD-3-Clause",
+            "MS-PL",
+            "GPL-2.0-or-later",
+            "Artistic-2.0",
+            "X11",
+            "MIT-old",
+            "TCL-like",
+            "BSD-3-clause-fjord",
+            "GPL-3.0-only",
+            "Zlib"
+          ],
+          "Maintainer": "Debian QA Group \u003cpackages@qa.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libdb-5.3.so",
+            "/usr/share/doc/libdb5.3t64/build_signature_amd64.txt",
+            "/usr/share/doc/libdb5.3t64/changelog.Debian.gz",
+            "/usr/share/doc/libdb5.3t64/copyright",
+            "/usr/share/lintian/overrides/libdb5.3t64"
+          ]
+        },
+        {
+          "ID": "libdebconfclient0@0.280",
+          "Name": "libdebconfclient0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libdebconfclient0@0.280?arch=amd64\u0026distro=debian-13.1",
+            "UID": "8723053ef24d112e"
+          },
+          "Version": "0.280",
+          "Arch": "amd64",
+          "SrcName": "cdebconf",
+          "SrcVersion": "0.280",
+          "Licenses": [
+            "BSD-2-Clause",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian Install System Team \u003cdebian-boot@lists.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libdebconfclient.so.0.0.0",
+            "/usr/share/doc/libdebconfclient0/changelog.gz",
+            "/usr/share/doc/libdebconfclient0/copyright"
+          ]
+        },
+        {
+          "ID": "libffi8@3.4.8-2",
+          "Name": "libffi8",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libffi8@3.4.8-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "f82eb0285aa276ae"
+          },
+          "Version": "3.4.8",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libffi",
+          "SrcVersion": "3.4.8",
+          "SrcRelease": "2",
+          "Licenses": [
+            "MIT",
+            "X11",
+            "GPL-2.0-or-later",
+            "GPL-3.0-or-later",
+            "MPL-1.1",
+            "LGPL-2.1-or-later",
+            "public-domain"
+          ],
+          "Maintainer": "Debian GCC Maintainers \u003cdebian-gcc@lists.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libffi.so.8.1.4",
+            "/usr/share/doc/libffi8/changelog.Debian.gz",
+            "/usr/share/doc/libffi8/copyright"
+          ]
+        },
+        {
+          "ID": "libgcc-s1@14.2.0-19",
+          "Name": "libgcc-s1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgcc-s1@14.2.0-19?arch=amd64\u0026distro=debian-13.1",
+            "UID": "813860d4d33b76b5"
+          },
+          "Version": "14.2.0",
+          "Release": "19",
+          "Arch": "amd64",
+          "SrcName": "gcc-14",
+          "SrcVersion": "14.2.0",
+          "SrcRelease": "19",
+          "Maintainer": "Debian GCC Maintainers \u003cdebian-gcc@lists.debian.org\u003e",
+          "DependsOn": [
+            "gcc-14-base@14.2.0-19",
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1",
+            "/usr/share/lintian/overrides/libgcc-s1"
+          ]
+        },
+        {
+          "ID": "libgdbm6t64@1.24-2",
+          "Name": "libgdbm6t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgdbm6t64@1.24-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b99a39628feda90"
+          },
+          "Version": "1.24",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "gdbm",
+          "SrcVersion": "1.24",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "GFDL-1.3-no-invariants-or-later",
+            "GPL-3.0-only",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Nicolas Mora \u003cbabelouest@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libgdbm.so.6.0.0",
+            "/usr/share/doc/libgdbm6t64/changelog.Debian.gz",
+            "/usr/share/doc/libgdbm6t64/changelog.gz",
+            "/usr/share/doc/libgdbm6t64/copyright",
+            "/usr/share/lintian/overrides/libgdbm6t64"
+          ]
+        },
+        {
+          "ID": "libgmp10@2:6.3.0+dfsg-3",
+          "Name": "libgmp10",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgmp10@6.3.0%2Bdfsg-3?arch=amd64\u0026distro=debian-13.1\u0026epoch=2",
+            "UID": "8f6394e4bf34bc90"
+          },
+          "Version": "6.3.0+dfsg",
+          "Release": "3",
+          "Epoch": 2,
+          "Arch": "amd64",
+          "SrcName": "gmp",
+          "SrcVersion": "6.3.0+dfsg",
+          "SrcRelease": "3",
+          "SrcEpoch": 2,
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-or-later",
+            "GPL-3+ with Bison exception",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Debian Science Maintainers \u003cdebian-science-maintainers@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libgmp.so.10.5.0",
+            "/usr/share/doc/libgmp10/README.Debian",
+            "/usr/share/doc/libgmp10/changelog.Debian.gz",
+            "/usr/share/doc/libgmp10/changelog.gz",
+            "/usr/share/doc/libgmp10/copyright"
+          ]
+        },
+        {
+          "ID": "libgnutls30t64@3.8.9-3",
+          "Name": "libgnutls30t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgnutls30t64@3.8.9-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ff33dbe4723118d9"
+          },
+          "Version": "3.8.9",
+          "Release": "3",
+          "Arch": "amd64",
+          "SrcName": "gnutls28",
+          "SrcVersion": "3.8.9",
+          "SrcRelease": "3",
+          "Licenses": [
+            "LGPL-2.1-only",
+            "LGPL-2.0-or-later",
+            "LGPL-3.0-only",
+            "GPL-2.0-or-later",
+            "GPL-3.0-only",
+            "GFDL-1.3-only",
+            "CC0-1.0",
+            "MIT",
+            "Apache-2.0",
+            "LGPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "GPL-3.0-or-later",
+            "BSD-3-Clause",
+            "FSFAP"
+          ],
+          "Maintainer": "Debian GnuTLS Maintainers \u003cpkg-gnutls-maint@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libgmp10@2:6.3.0+dfsg-3",
+            "libhogweed6t64@3.10.1-1",
+            "libidn2-0@2.3.8-2",
+            "libnettle8t64@3.10.1-1",
+            "libp11-kit0@0.25.5-3",
+            "libtasn1-6@4.20.0-2",
+            "libunistring5@1.3-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libgnutls.so.30.40.3",
+            "/usr/share/doc/libgnutls30t64/AUTHORS.gz",
+            "/usr/share/doc/libgnutls30t64/NEWS.gz",
+            "/usr/share/doc/libgnutls30t64/README.md.gz",
+            "/usr/share/doc/libgnutls30t64/THANKS.gz",
+            "/usr/share/doc/libgnutls30t64/changelog.Debian.gz",
+            "/usr/share/doc/libgnutls30t64/changelog.gz",
+            "/usr/share/doc/libgnutls30t64/copyright",
+            "/usr/share/lintian/overrides/libgnutls30t64",
+            "/usr/share/locale/cs/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/de/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/es/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/it/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/gnutls30.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/gnutls30.mo"
+          ]
+        },
+        {
+          "ID": "libgssapi-krb5-2@1.21.3-5",
+          "Name": "libgssapi-krb5-2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgssapi-krb5-2@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e981ef95af866663"
+          },
+          "Version": "1.21.3",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "krb5",
+          "SrcVersion": "1.21.3",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libcom-err2@1.47.2-3+b3",
+            "libk5crypto3@1.21.3-5",
+            "libkrb5-3@1.21.3-5",
+            "libkrb5support0@1.21.3-5"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2",
+            "/usr/share/doc/libgssapi-krb5-2/changelog.Debian.gz",
+            "/usr/share/doc/libgssapi-krb5-2/copyright",
+            "/usr/share/lintian/overrides/libgssapi-krb5-2"
+          ]
+        },
+        {
+          "ID": "libhogweed6t64@3.10.1-1",
+          "Name": "libhogweed6t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libhogweed6t64@3.10.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "93d12a6ea6e63e7b"
+          },
+          "Version": "3.10.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "nettle",
+          "SrcVersion": "3.10.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "LGPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "MIT",
+            "GPL-3.0-with-autoconf-exception+",
+            "public-domain",
+            "GPL-2.0-only",
+            "GAP"
+          ],
+          "Maintainer": "Magnus Holmgren \u003cholmgren@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libgmp10@2:6.3.0+dfsg-3",
+            "libnettle8t64@3.10.1-1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libhogweed.so.6.10",
+            "/usr/share/doc/libhogweed6t64/changelog.Debian.gz",
+            "/usr/share/doc/libhogweed6t64/changelog.gz",
+            "/usr/share/doc/libhogweed6t64/copyright",
+            "/usr/share/lintian/overrides/libhogweed6t64"
+          ]
+        },
+        {
+          "ID": "libidn2-0@2.3.8-2",
+          "Name": "libidn2-0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libidn2-0@2.3.8-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "47a6bc21cc7f22ac"
+          },
+          "Version": "2.3.8",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libidn2",
+          "SrcVersion": "2.3.8",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "LGPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "MIT",
+            "Unicode",
+            "GPL-3.0-only",
+            "GPL-2.0-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Debian Libidn team \u003chelp-libidn@gnu.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libunistring5@1.3-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libidn2.so.0.4.0",
+            "/usr/share/doc/libidn2-0/AUTHORS",
+            "/usr/share/doc/libidn2-0/NEWS.gz",
+            "/usr/share/doc/libidn2-0/README.md.gz",
+            "/usr/share/doc/libidn2-0/changelog.Debian.gz",
+            "/usr/share/doc/libidn2-0/copyright",
+            "/usr/share/lintian/overrides/libidn2-0",
+            "/usr/share/locale/cs/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/da/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/de/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/es/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/fur/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/id/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/it/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/lv/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/libidn2.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/libidn2.mo"
+          ]
+        },
+        {
+          "ID": "libk5crypto3@1.21.3-5",
+          "Name": "libk5crypto3",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libk5crypto3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "654244e38d239af9"
+          },
+          "Version": "1.21.3",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "krb5",
+          "SrcVersion": "1.21.3",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libkrb5support0@1.21.3-5"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1",
+            "/usr/share/doc/libk5crypto3/changelog.Debian.gz",
+            "/usr/share/doc/libk5crypto3/copyright"
+          ]
+        },
+        {
+          "ID": "libkeyutils1@1.6.3-6",
+          "Name": "libkeyutils1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libkeyutils1@1.6.3-6?arch=amd64\u0026distro=debian-13.1",
+            "UID": "f0a9f8df0ae9e579"
+          },
+          "Version": "1.6.3",
+          "Release": "6",
+          "Arch": "amd64",
+          "SrcName": "keyutils",
+          "SrcVersion": "1.6.3",
+          "SrcRelease": "6",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "LGPL-2.0-or-later",
+            "GPL-2.0-only",
+            "LGPL-2.0-only"
+          ],
+          "Maintainer": "Christian Kastner \u003cckk@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10",
+            "/usr/share/doc/libkeyutils1/changelog.Debian.gz",
+            "/usr/share/doc/libkeyutils1/copyright"
+          ]
+        },
+        {
+          "ID": "libkrb5-3@1.21.3-5",
+          "Name": "libkrb5-3",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libkrb5-3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42eb2a7522db520b"
+          },
+          "Version": "1.21.3",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "krb5",
+          "SrcVersion": "1.21.3",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libcom-err2@1.47.2-3+b3",
+            "libk5crypto3@1.21.3-5",
+            "libkeyutils1@1.6.3-6",
+            "libkrb5support0@1.21.3-5",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/krb5/plugins/preauth/spake.so",
+            "/usr/lib/x86_64-linux-gnu/libkrb5.so.3.3",
+            "/usr/share/doc/libkrb5-3/README.Debian",
+            "/usr/share/doc/libkrb5-3/README.gz",
+            "/usr/share/doc/libkrb5-3/changelog.Debian.gz",
+            "/usr/share/doc/libkrb5-3/copyright",
+            "/usr/share/lintian/overrides/libkrb5-3"
+          ]
+        },
+        {
+          "ID": "libkrb5support0@1.21.3-5",
+          "Name": "libkrb5support0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libkrb5support0@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7b7b2ceb7abdb0a3"
+          },
+          "Version": "1.21.3",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "krb5",
+          "SrcVersion": "1.21.3",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1",
+            "/usr/share/doc/libkrb5support0/changelog.Debian.gz",
+            "/usr/share/doc/libkrb5support0/copyright",
+            "/usr/share/lintian/overrides/libkrb5support0"
+          ]
+        },
+        {
+          "ID": "liblastlog2-2@2.41-5",
+          "Name": "liblastlog2-2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/liblastlog2-2@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "df76396cbfd04981"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libsqlite3-0@3.46.1-7"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/liblastlog2.so.2.0.0",
+            "/usr/share/doc/liblastlog2-2/NEWS.Debian.gz",
+            "/usr/share/doc/liblastlog2-2/changelog.Debian.gz",
+            "/usr/share/doc/liblastlog2-2/changelog.gz",
+            "/usr/share/doc/liblastlog2-2/copyright"
+          ]
+        },
+        {
+          "ID": "libldap-common@2.6.10+dfsg-1",
+          "Name": "libldap-common",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libldap-common@2.6.10%2Bdfsg-1?arch=all\u0026distro=debian-13.1",
+            "UID": "1e651153267a4241"
+          },
+          "Version": "2.6.10+dfsg",
+          "Release": "1",
+          "Arch": "all",
+          "SrcName": "openldap",
+          "SrcVersion": "2.6.10+dfsg",
+          "SrcRelease": "1",
+          "Licenses": [
+            "OpenLDAP-2.8",
+            "FSF-unlimited",
+            "GPL-2.0-with-autoconf-exception+",
+            "GPL-3.0-with-autoconf-exception+",
+            "GPL-2+ with Libtool exception",
+            "GPL-3+ with Libtool exception",
+            "GPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "UMich",
+            "F5",
+            "JCG",
+            "MIT-XC",
+            "NeoSoft-permissive",
+            "BSD-3-Clause",
+            "Beerware",
+            "public-domain",
+            "BSD-4-clause-California",
+            "BSD-3-clause-variant",
+            "Expat-ISC",
+            "Expat-UNM",
+            "MIT",
+            "BSD-3-clause-California",
+            "GPL-2.0-only",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Debian OpenLDAP Maintainers \u003cpkg-openldap-devel@lists.alioth.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/libldap-common/NEWS.Debian.gz",
+            "/usr/share/doc/libldap-common/changelog.Debian.gz",
+            "/usr/share/doc/libldap-common/changelog.gz",
+            "/usr/share/doc/libldap-common/copyright",
+            "/usr/share/man/man5/ldap.conf.5.gz"
+          ]
+        },
+        {
+          "ID": "libldap2@2.6.10+dfsg-1",
+          "Name": "libldap2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "57ebb4268feab87d"
+          },
+          "Version": "2.6.10+dfsg",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "openldap",
+          "SrcVersion": "2.6.10+dfsg",
+          "SrcRelease": "1",
+          "Licenses": [
+            "OpenLDAP-2.8",
+            "FSF-unlimited",
+            "GPL-2.0-with-autoconf-exception+",
+            "GPL-3.0-with-autoconf-exception+",
+            "GPL-2+ with Libtool exception",
+            "GPL-3+ with Libtool exception",
+            "GPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "UMich",
+            "F5",
+            "JCG",
+            "MIT-XC",
+            "NeoSoft-permissive",
+            "BSD-3-Clause",
+            "Beerware",
+            "public-domain",
+            "BSD-4-clause-California",
+            "BSD-3-clause-variant",
+            "Expat-ISC",
+            "Expat-UNM",
+            "MIT",
+            "BSD-3-clause-California",
+            "GPL-2.0-only",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Debian OpenLDAP Maintainers \u003cpkg-openldap-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libsasl2-2@2.1.28+dfsg1-9",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/liblber.so.2.0.200",
+            "/usr/lib/x86_64-linux-gnu/libldap.so.2.0.200",
+            "/usr/share/doc/libldap2/NEWS.Debian.gz",
+            "/usr/share/doc/libldap2/changelog.Debian.gz",
+            "/usr/share/doc/libldap2/changelog.gz",
+            "/usr/share/doc/libldap2/copyright"
+          ]
+        },
+        {
+          "ID": "liblz4-1@1.10.0-4",
+          "Name": "liblz4-1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/liblz4-1@1.10.0-4?arch=amd64\u0026distro=debian-13.1",
+            "UID": "5be603ddb02c650f"
+          },
+          "Version": "1.10.0",
+          "Release": "4",
+          "Arch": "amd64",
+          "SrcName": "lz4",
+          "SrcVersion": "1.10.0",
+          "SrcRelease": "4",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "BSD-2-Clause",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Nobuhiro Iwamatsu \u003ciwamatsu@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libxxhash0@0.8.3-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/liblz4.so.1.10.0",
+            "/usr/share/doc/liblz4-1/changelog.Debian.gz",
+            "/usr/share/doc/liblz4-1/copyright"
+          ]
+        },
+        {
+          "ID": "liblzma5@5.8.1-1",
+          "Name": "liblzma5",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/liblzma5@5.8.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "88e7a89cb6723d88"
+          },
+          "Version": "5.8.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "xz-utils",
+          "SrcVersion": "5.8.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "0BSD",
+            "GPL-2.0-or-later",
+            "LGPL-2.1-or-later",
+            "FSFULLR",
+            "GPL-3.0-or-later-WITH-Autoconf-exception-macro",
+            "none",
+            "PD",
+            "permissive-nowarranty",
+            "FSFUL",
+            "noderivs",
+            "PD-debian",
+            "LGPL-2.1-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Sebastian Andrzej Siewior \u003csebastian@breakpoint.cc\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/liblzma.so.5.8.1",
+            "/usr/share/doc/liblzma5/AUTHORS",
+            "/usr/share/doc/liblzma5/NEWS.gz",
+            "/usr/share/doc/liblzma5/THANKS.gz",
+            "/usr/share/doc/liblzma5/changelog.Debian.gz",
+            "/usr/share/doc/liblzma5/changelog.gz",
+            "/usr/share/doc/liblzma5/copyright"
+          ]
+        },
+        {
+          "ID": "libmd0@1.1.0-2+b1",
+          "Name": "libmd0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libmd0@1.1.0-2%2Bb1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "23d60256b09c2ba7"
+          },
+          "Version": "1.1.0",
+          "Release": "2+b1",
+          "Arch": "amd64",
+          "SrcName": "libmd",
+          "SrcVersion": "1.1.0",
+          "SrcRelease": "2",
+          "Licenses": [
+            "BSD-3-Clause",
+            "BSD-3-clause-Aaron-D-Gifford",
+            "BSD-2-Clause",
+            "BSD-2-Clause-NetBSD",
+            "ISC",
+            "Beerware",
+            "public-domain-md4",
+            "public-domain-md5",
+            "public-domain-sha1"
+          ],
+          "Maintainer": "Guillem Jover \u003cguillem@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libmd.so.0.1.0",
+            "/usr/share/doc/libmd0/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libmd0/changelog.Debian.gz",
+            "/usr/share/doc/libmd0/changelog.gz",
+            "/usr/share/doc/libmd0/copyright"
+          ]
+        },
+        {
+          "ID": "libmount1@2.41-5",
+          "Name": "libmount1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libmount1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6d2d7374cd54451e"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libblkid1@2.41-5",
+            "libc6@2.41-12",
+            "libselinux1@3.8.1-1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libmount.so.1.1.0",
+            "/usr/share/doc/libmount1/NEWS.Debian.gz",
+            "/usr/share/doc/libmount1/changelog.Debian.gz",
+            "/usr/share/doc/libmount1/changelog.gz",
+            "/usr/share/doc/libmount1/copyright",
+            "/usr/share/lintian/overrides/libmount1"
+          ]
+        },
+        {
+          "ID": "libncursesw6@6.5+20250216-2",
+          "Name": "libncursesw6",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libncursesw6@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "9ab389651a2b5886"
+          },
+          "Version": "6.5+20250216",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "ncurses",
+          "SrcVersion": "6.5+20250216",
+          "SrcRelease": "2",
+          "Maintainer": "Ncurses Maintainers \u003cncurses@packages.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libtinfo6@6.5+20250216-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libformw.so.6.5",
+            "/usr/lib/x86_64-linux-gnu/libmenuw.so.6.5",
+            "/usr/lib/x86_64-linux-gnu/libncursesw.so.6.5",
+            "/usr/lib/x86_64-linux-gnu/libpanelw.so.6.5"
+          ]
+        },
+        {
+          "ID": "libnettle8t64@3.10.1-1",
+          "Name": "libnettle8t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libnettle8t64@3.10.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "48343658214e46b4"
+          },
+          "Version": "3.10.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "nettle",
+          "SrcVersion": "3.10.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "LGPL-3.0-or-later",
+            "GPL-2.0-or-later",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "MIT",
+            "GPL-3.0-with-autoconf-exception+",
+            "public-domain",
+            "GPL-2.0-only",
+            "GAP"
+          ],
+          "Maintainer": "Magnus Holmgren \u003cholmgren@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libnettle.so.8.10",
+            "/usr/share/doc/libnettle8t64/NEWS.gz",
+            "/usr/share/doc/libnettle8t64/README",
+            "/usr/share/doc/libnettle8t64/changelog.Debian.gz",
+            "/usr/share/doc/libnettle8t64/changelog.gz",
+            "/usr/share/doc/libnettle8t64/copyright",
+            "/usr/share/lintian/overrides/libnettle8t64"
+          ]
+        },
+        {
+          "ID": "libnghttp2-14@1.64.0-1.1",
+          "Name": "libnghttp2-14",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libnghttp2-14@1.64.0-1.1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "f376b263487ca4e4"
+          },
+          "Version": "1.64.0",
+          "Release": "1.1",
+          "Arch": "amd64",
+          "SrcName": "nghttp2",
+          "SrcVersion": "1.64.0",
+          "SrcRelease": "1.1",
+          "Licenses": [
+            "MIT",
+            "all-permissive",
+            "GPL-3.0-with-autoconf-exception+",
+            "BSD-2-Clause",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Tomasz Buchert \u003ctomasz@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libnghttp2.so.14.28.3",
+            "/usr/share/doc/libnghttp2-14/AUTHORS",
+            "/usr/share/doc/libnghttp2-14/README.rst.gz",
+            "/usr/share/doc/libnghttp2-14/changelog.Debian.gz",
+            "/usr/share/doc/libnghttp2-14/copyright"
+          ]
+        },
+        {
+          "ID": "libnghttp3-9@1.8.0-1",
+          "Name": "libnghttp3-9",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libnghttp3-9@1.8.0-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6121db78bc4981ea"
+          },
+          "Version": "1.8.0",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "nghttp3",
+          "SrcVersion": "1.8.0",
+          "SrcRelease": "1",
+          "Licenses": [
+            "MIT",
+            "FSFULLR",
+            "GPL-3+ with Autoconf generic exception",
+            "FSFUL",
+            "GPL-2+ with Autoconf generic exception",
+            "FSFAP",
+            "GPL-2+ with Libtool Exception",
+            "GPL-3.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-only"
+          ],
+          "Maintainer": "Debian Curl Maintainers \u003cteam+curl@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libnghttp3.so.9.2.6",
+            "/usr/share/doc/libnghttp3-9/changelog.Debian.gz",
+            "/usr/share/doc/libnghttp3-9/changelog.gz",
+            "/usr/share/doc/libnghttp3-9/copyright"
+          ]
+        },
+        {
+          "ID": "libp11-kit0@0.25.5-3",
+          "Name": "libp11-kit0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libp11-kit0@0.25.5-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a86f7aa7673142c"
+          },
+          "Version": "0.25.5",
+          "Release": "3",
+          "Arch": "amd64",
+          "SrcName": "p11-kit",
+          "SrcVersion": "0.25.5",
+          "SrcRelease": "3",
+          "Licenses": [
+            "BSD-3-Clause",
+            "FSFULLR",
+            "GPL-2+ with Autoconf-data exception",
+            "GPL-3+ with Autoconf-data exception",
+            "X11",
+            "ISC",
+            "customFSFULLRWD",
+            "LGPL-2.1-or-later",
+            "Apache-2.0",
+            "customFSFUL",
+            "FSFAP",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Debian GnuTLS Maintainers \u003cpkg-gnutls-maint@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libffi8@3.4.8-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.4.1",
+            "/usr/share/doc/libp11-kit0/changelog.Debian.gz",
+            "/usr/share/doc/libp11-kit0/changelog.gz",
+            "/usr/share/doc/libp11-kit0/copyright",
+            "/usr/share/doc/libp11-kit0/examples/pkcs11.conf.example"
+          ]
+        },
+        {
+          "ID": "libpam-modules@1.7.0-5",
+          "Name": "libpam-modules",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpam-modules@1.7.0-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b9d6f9c66558c40d"
+          },
+          "Version": "1.7.0",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "pam",
+          "SrcVersion": "1.7.0",
+          "SrcRelease": "5",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-or-later",
+            "GPL-1.0-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "BSD-tcp_wrappers",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "public-domain",
+            "Beerware"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/security/pam_access.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_canonicalize_user.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_debug.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_deny.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_echo.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_env.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_exec.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_faildelay.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_faillock.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_filter.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_ftp.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_group.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_issue.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_keyinit.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_limits.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_listfile.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_localuser.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_loginuid.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_mail.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_mkhomedir.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_motd.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_namespace.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_nologin.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_permit.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_pwhistory.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_rhosts.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_rootok.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_securetty.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_selinux.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_sepermit.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_setquota.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_shells.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_stress.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_succeed_if.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_time.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_timestamp.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_tty_audit.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_umask.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_unix.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_userdb.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_usertype.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_warn.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_wheel.so",
+            "/usr/lib/x86_64-linux-gnu/security/pam_xauth.so",
+            "/usr/share/doc/libpam-modules/NEWS.Debian.gz",
+            "/usr/share/doc/libpam-modules/changelog.Debian.gz",
+            "/usr/share/doc/libpam-modules/changelog.gz",
+            "/usr/share/doc/libpam-modules/copyright",
+            "/usr/share/doc/libpam-modules/examples/upperLOWER.c",
+            "/usr/share/lintian/overrides/libpam-modules",
+            "/usr/share/pam-configs/mkhomedir"
+          ]
+        },
+        {
+          "ID": "libpam-modules-bin@1.7.0-5",
+          "Name": "libpam-modules-bin",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpam-modules-bin@1.7.0-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bb305b59765ff43e"
+          },
+          "Version": "1.7.0",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "pam",
+          "SrcVersion": "1.7.0",
+          "SrcRelease": "5",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-or-later",
+            "GPL-1.0-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "BSD-tcp_wrappers",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "public-domain",
+            "Beerware"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "libaudit1@1:4.0.2-2+b2",
+            "libc6@2.41-12",
+            "libcrypt1@1:4.4.38-1",
+            "libpam0g@1.7.0-5",
+            "libselinux1@3.8.1-1",
+            "libsystemd0@257.8-1~deb13u2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/systemd/system/pam_namespace.service",
+            "/usr/sbin/faillock",
+            "/usr/sbin/mkhomedir_helper",
+            "/usr/sbin/pam_namespace_helper",
+            "/usr/sbin/pam_timestamp_check",
+            "/usr/sbin/pwhistory_helper",
+            "/usr/sbin/unix_chkpwd",
+            "/usr/sbin/unix_update",
+            "/usr/share/doc/libpam-modules-bin/changelog.Debian.gz",
+            "/usr/share/doc/libpam-modules-bin/changelog.gz",
+            "/usr/share/doc/libpam-modules-bin/copyright",
+            "/usr/share/lintian/overrides/libpam-modules-bin"
+          ]
+        },
+        {
+          "ID": "libpam-runtime@1.7.0-5",
+          "Name": "libpam-runtime",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpam-runtime@1.7.0-5?arch=all\u0026distro=debian-13.1",
+            "UID": "2e8bd19930283d52"
+          },
+          "Version": "1.7.0",
+          "Release": "5",
+          "Arch": "all",
+          "SrcName": "pam",
+          "SrcVersion": "1.7.0",
+          "SrcRelease": "5",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-or-later",
+            "GPL-1.0-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "BSD-tcp_wrappers",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "public-domain",
+            "Beerware"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "debconf@1.5.91",
+            "libpam-modules@1.7.0-5"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/sbin/pam-auth-update",
+            "/usr/sbin/pam_getenv",
+            "/usr/share/doc/libpam-runtime/changelog.Debian.gz",
+            "/usr/share/doc/libpam-runtime/changelog.gz",
+            "/usr/share/doc/libpam-runtime/copyright",
+            "/usr/share/lintian/overrides/libpam-runtime",
+            "/usr/share/locale/af/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/am/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ar/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/as/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/az/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/be/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/bn/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/bn_IN/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/bs/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/cy/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/da/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/de/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/de_CH/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/el/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/es/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/et/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/fa/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/gu/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/he/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/hi/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ia/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/id/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/is/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/it/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/kk/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/km/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/kn/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/kw_GB/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ky/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/lt/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/lv/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/mk/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ml/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/mn/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/mr/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/my/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ne/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/nn/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/or/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/pa/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/si/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sq/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sr@latin/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ta/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/te/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/tg/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/th/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/ur/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/yo/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/zh_HK/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/locale/zu/LC_MESSAGES/Linux-PAM.mo",
+            "/usr/share/man/man5/access.conf.5.gz",
+            "/usr/share/man/man5/faillock.conf.5.gz",
+            "/usr/share/man/man5/group.conf.5.gz",
+            "/usr/share/man/man5/limits.conf.5.gz",
+            "/usr/share/man/man5/namespace.conf.5.gz",
+            "/usr/share/man/man5/pam.conf.5.gz",
+            "/usr/share/man/man5/pam_env.conf.5.gz",
+            "/usr/share/man/man5/pwhistory.conf.5.gz",
+            "/usr/share/man/man5/sepermit.conf.5.gz",
+            "/usr/share/man/man5/time.conf.5.gz",
+            "/usr/share/man/man7/PAM.7.gz",
+            "/usr/share/man/man8/faillock.8.gz",
+            "/usr/share/man/man8/mkhomedir_helper.8.gz",
+            "/usr/share/man/man8/pam-auth-update.8.gz",
+            "/usr/share/man/man8/pam_access.8.gz",
+            "/usr/share/man/man8/pam_canonicalize_user.8.gz",
+            "/usr/share/man/man8/pam_debug.8.gz",
+            "/usr/share/man/man8/pam_deny.8.gz",
+            "/usr/share/man/man8/pam_echo.8.gz",
+            "/usr/share/man/man8/pam_env.8.gz",
+            "/usr/share/man/man8/pam_exec.8.gz",
+            "/usr/share/man/man8/pam_faildelay.8.gz",
+            "/usr/share/man/man8/pam_faillock.8.gz",
+            "/usr/share/man/man8/pam_filter.8.gz",
+            "/usr/share/man/man8/pam_ftp.8.gz",
+            "/usr/share/man/man8/pam_getenv.8.gz",
+            "/usr/share/man/man8/pam_group.8.gz",
+            "/usr/share/man/man8/pam_issue.8.gz",
+            "/usr/share/man/man8/pam_keyinit.8.gz",
+            "/usr/share/man/man8/pam_limits.8.gz",
+            "/usr/share/man/man8/pam_listfile.8.gz",
+            "/usr/share/man/man8/pam_localuser.8.gz",
+            "/usr/share/man/man8/pam_loginuid.8.gz",
+            "/usr/share/man/man8/pam_mail.8.gz",
+            "/usr/share/man/man8/pam_mkhomedir.8.gz",
+            "/usr/share/man/man8/pam_motd.8.gz",
+            "/usr/share/man/man8/pam_namespace.8.gz",
+            "/usr/share/man/man8/pam_namespace_helper.8.gz",
+            "/usr/share/man/man8/pam_nologin.8.gz",
+            "/usr/share/man/man8/pam_permit.8.gz",
+            "/usr/share/man/man8/pam_pwhistory.8.gz",
+            "/usr/share/man/man8/pam_rhosts.8.gz",
+            "/usr/share/man/man8/pam_rootok.8.gz",
+            "/usr/share/man/man8/pam_securetty.8.gz",
+            "/usr/share/man/man8/pam_selinux.8.gz",
+            "/usr/share/man/man8/pam_sepermit.8.gz",
+            "/usr/share/man/man8/pam_setquota.8.gz",
+            "/usr/share/man/man8/pam_shells.8.gz",
+            "/usr/share/man/man8/pam_stress.8.gz",
+            "/usr/share/man/man8/pam_succeed_if.8.gz",
+            "/usr/share/man/man8/pam_time.8.gz",
+            "/usr/share/man/man8/pam_timestamp.8.gz",
+            "/usr/share/man/man8/pam_timestamp_check.8.gz",
+            "/usr/share/man/man8/pam_tty_audit.8.gz",
+            "/usr/share/man/man8/pam_umask.8.gz",
+            "/usr/share/man/man8/pam_unix.8.gz",
+            "/usr/share/man/man8/pam_userdb.8.gz",
+            "/usr/share/man/man8/pam_usertype.8.gz",
+            "/usr/share/man/man8/pam_warn.8.gz",
+            "/usr/share/man/man8/pam_wheel.8.gz",
+            "/usr/share/man/man8/pam_xauth.8.gz",
+            "/usr/share/man/man8/pwhistory_helper.8.gz",
+            "/usr/share/man/man8/unix_chkpwd.8.gz",
+            "/usr/share/man/man8/unix_update.8.gz",
+            "/usr/share/pam-configs/unix",
+            "/usr/share/pam/common-account",
+            "/usr/share/pam/common-account.md5sums",
+            "/usr/share/pam/common-auth",
+            "/usr/share/pam/common-auth.md5sums",
+            "/usr/share/pam/common-password",
+            "/usr/share/pam/common-password.md5sums",
+            "/usr/share/pam/common-session",
+            "/usr/share/pam/common-session-noninteractive",
+            "/usr/share/pam/common-session-noninteractive.md5sums",
+            "/usr/share/pam/common-session.md5sums"
+          ]
+        },
+        {
+          "ID": "libpam0g@1.7.0-5",
+          "Name": "libpam0g",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpam0g@1.7.0-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7c64fa0e3792081f"
+          },
+          "Version": "1.7.0",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "pam",
+          "SrcVersion": "1.7.0",
+          "SrcRelease": "5",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-or-later",
+            "GPL-1.0-only",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "BSD-tcp_wrappers",
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only",
+            "public-domain",
+            "Beerware"
+          ],
+          "Maintainer": "Sam Hartman \u003chartmans@debian.org\u003e",
+          "DependsOn": [
+            "debconf@1.5.91",
+            "libaudit1@1:4.0.2-2+b2",
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libpam.so.0.85.1",
+            "/usr/lib/x86_64-linux-gnu/libpam_misc.so.0.82.1",
+            "/usr/lib/x86_64-linux-gnu/libpamc.so.0.82.1",
+            "/usr/share/doc/libpam0g/Debian-PAM-MiniPolicy.gz",
+            "/usr/share/doc/libpam0g/README",
+            "/usr/share/doc/libpam0g/README.Debian",
+            "/usr/share/doc/libpam0g/TODO.Debian",
+            "/usr/share/doc/libpam0g/changelog.Debian.gz",
+            "/usr/share/doc/libpam0g/changelog.gz",
+            "/usr/share/doc/libpam0g/copyright",
+            "/usr/share/lintian/overrides/libpam0g"
+          ]
+        },
+        {
+          "ID": "libpcre2-8-0@10.46-1~deb13u1",
+          "Name": "libpcre2-8-0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpcre2-8-0@10.46-1~deb13u1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e711d6472730c634"
+          },
+          "Version": "10.46",
+          "Release": "1~deb13u1",
+          "Arch": "amd64",
+          "SrcName": "pcre2",
+          "SrcVersion": "10.46",
+          "SrcRelease": "1~deb13u1",
+          "Licenses": [
+            "BSD-3-clause-Cambridge with BINARY LIBRARY-LIKE PACKAGES exception",
+            "BSD-3-Clause",
+            "X11",
+            "BSD-2-Clause",
+            "public-domain"
+          ],
+          "Maintainer": "Matthew Vernon \u003cmatthew@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.14.0",
+            "/usr/share/doc/libpcre2-8-0/README.Debian",
+            "/usr/share/doc/libpcre2-8-0/changelog.Debian.gz",
+            "/usr/share/doc/libpcre2-8-0/changelog.gz",
+            "/usr/share/doc/libpcre2-8-0/copyright"
+          ]
+        },
+        {
+          "ID": "libpsl5t64@0.21.2-1.1+b1",
+          "Name": "libpsl5t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libpsl5t64@0.21.2-1.1%2Bb1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d20843970880c215"
+          },
+          "Version": "0.21.2",
+          "Release": "1.1+b1",
+          "Arch": "amd64",
+          "SrcName": "libpsl",
+          "SrcVersion": "0.21.2",
+          "SrcRelease": "1.1",
+          "Licenses": [
+            "MIT",
+            "gnulib",
+            "Chromium"
+          ],
+          "Maintainer": "Tim Rühsen \u003ctim.ruehsen@gmx.de\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libidn2-0@2.3.8-2",
+            "libunistring5@1.3-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4",
+            "/usr/share/doc/libpsl5t64/changelog.Debian.amd64.gz",
+            "/usr/share/doc/libpsl5t64/changelog.Debian.gz",
+            "/usr/share/doc/libpsl5t64/changelog.gz",
+            "/usr/share/doc/libpsl5t64/copyright",
+            "/usr/share/lintian/overrides/libpsl5t64"
+          ]
+        },
+        {
+          "ID": "libreadline8t64@8.2-6",
+          "Name": "libreadline8t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libreadline8t64@8.2-6?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bca17e0f70f9fb49"
+          },
+          "Version": "8.2",
+          "Release": "6",
+          "Arch": "amd64",
+          "SrcName": "readline",
+          "SrcVersion": "8.2",
+          "SrcRelease": "6",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GFDL-1.3-no-invariants-or-later",
+            "GFDL-1.3-or-later",
+            "ISC-no-attribution"
+          ],
+          "Maintainer": "Matthias Klose \u003cdoko@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libtinfo6@6.5+20250216-2",
+            "readline-common@8.2-6"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libhistory.so.8.2",
+            "/usr/lib/x86_64-linux-gnu/libreadline.so.8.2",
+            "/usr/share/doc/libreadline8t64/README.Debian",
+            "/usr/share/doc/libreadline8t64/USAGE",
+            "/usr/share/doc/libreadline8t64/changelog.Debian.gz",
+            "/usr/share/doc/libreadline8t64/changelog.gz",
+            "/usr/share/doc/libreadline8t64/copyright",
+            "/usr/share/doc/libreadline8t64/examples/Inputrc",
+            "/usr/share/doc/libreadline8t64/inputrc.arrows"
+          ]
+        },
+        {
+          "ID": "librtmp1@2.4+20151223.gitfa8646d.1-2+b5",
+          "Name": "librtmp1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/librtmp1@2.4%2B20151223.gitfa8646d.1-2%2Bb5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7514aec3addd68f5"
+          },
+          "Version": "2.4+20151223.gitfa8646d.1",
+          "Release": "2+b5",
+          "Arch": "amd64",
+          "SrcName": "rtmpdump",
+          "SrcVersion": "2.4+20151223.gitfa8646d.1",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Debian Multimedia Maintainers \u003cdebian-multimedia@lists.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libgmp10@2:6.3.0+dfsg-3",
+            "libgnutls30t64@3.8.9-3",
+            "libhogweed6t64@3.10.1-1",
+            "libnettle8t64@3.10.1-1",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/librtmp.so.1",
+            "/usr/share/doc/librtmp1/changelog.Debian.amd64.gz",
+            "/usr/share/doc/librtmp1/changelog.Debian.gz",
+            "/usr/share/doc/librtmp1/changelog.gz",
+            "/usr/share/doc/librtmp1/copyright"
+          ]
+        },
+        {
+          "ID": "libsasl2-2@2.1.28+dfsg1-9",
+          "Name": "libsasl2-2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsasl2-2@2.1.28%2Bdfsg1-9?arch=amd64\u0026distro=debian-13.1",
+            "UID": "52ae8c0b451424c8"
+          },
+          "Version": "2.1.28+dfsg1",
+          "Release": "9",
+          "Arch": "amd64",
+          "SrcName": "cyrus-sasl2",
+          "SrcVersion": "2.1.28+dfsg1",
+          "SrcRelease": "9",
+          "Licenses": [
+            "BSD-3-Clause-Attribution",
+            "BSD-3-Clause",
+            "BSD-2-Clause",
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "BSD-4-Clause-UC",
+            "RSA-MD",
+            "text://BSD-3-Clause-Attribution and IBM-as-is",
+            "BSD-3-clause-JANET",
+            "BSD-3-clause-PADL",
+            "MIT-OpenVision",
+            "OpenLDAP",
+            "FSFULLR",
+            "MIT-CMU",
+            "MIT-Export",
+            "BSD-2.2-clause",
+            "text://IBM-as-is"
+          ],
+          "Maintainer": "Debian Cyrus Team \u003cteam+cyrus@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libsasl2-modules-db@2.1.28+dfsg1-9",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25",
+            "/usr/share/doc/libsasl2-2/README.Debian",
+            "/usr/share/doc/libsasl2-2/changelog.Debian.gz",
+            "/usr/share/doc/libsasl2-2/copyright",
+            "/usr/share/man/man5/libsasl.5.gz"
+          ]
+        },
+        {
+          "ID": "libsasl2-modules@2.1.28+dfsg1-9",
+          "Name": "libsasl2-modules",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsasl2-modules@2.1.28%2Bdfsg1-9?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7e4b6f3fc2f20ef9"
+          },
+          "Version": "2.1.28+dfsg1",
+          "Release": "9",
+          "Arch": "amd64",
+          "SrcName": "cyrus-sasl2",
+          "SrcVersion": "2.1.28+dfsg1",
+          "SrcRelease": "9",
+          "Licenses": [
+            "BSD-3-Clause-Attribution",
+            "BSD-3-Clause",
+            "BSD-2-Clause",
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "BSD-4-Clause-UC",
+            "RSA-MD",
+            "text://BSD-3-Clause-Attribution and IBM-as-is",
+            "BSD-3-clause-JANET",
+            "BSD-3-clause-PADL",
+            "MIT-OpenVision",
+            "OpenLDAP",
+            "FSFULLR",
+            "MIT-CMU",
+            "MIT-Export",
+            "BSD-2.2-clause",
+            "text://IBM-as-is"
+          ],
+          "Maintainer": "Debian Cyrus Team \u003cteam+cyrus@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/sasl2/libanonymous.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/libcrammd5.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/libdigestmd5.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/liblogin.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/libntlm.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/libplain.so.2.0.25",
+            "/usr/lib/x86_64-linux-gnu/sasl2/libscram.so.2.0.25",
+            "/usr/share/doc/libsasl2-modules/changelog.Debian.gz",
+            "/usr/share/doc/libsasl2-modules/copyright"
+          ]
+        },
+        {
+          "ID": "libsasl2-modules-db@2.1.28+dfsg1-9",
+          "Name": "libsasl2-modules-db",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsasl2-modules-db@2.1.28%2Bdfsg1-9?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42fb653a374e0902"
+          },
+          "Version": "2.1.28+dfsg1",
+          "Release": "9",
+          "Arch": "amd64",
+          "SrcName": "cyrus-sasl2",
+          "SrcVersion": "2.1.28+dfsg1",
+          "SrcRelease": "9",
+          "Licenses": [
+            "BSD-3-Clause-Attribution",
+            "BSD-3-Clause",
+            "BSD-2-Clause",
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "BSD-4-Clause-UC",
+            "RSA-MD",
+            "text://BSD-3-Clause-Attribution and IBM-as-is",
+            "BSD-3-clause-JANET",
+            "BSD-3-clause-PADL",
+            "MIT-OpenVision",
+            "OpenLDAP",
+            "FSFULLR",
+            "MIT-CMU",
+            "MIT-Export",
+            "BSD-2.2-clause",
+            "text://IBM-as-is"
+          ],
+          "Maintainer": "Debian Cyrus Team \u003cteam+cyrus@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libdb5.3t64@5.3.28+dfsg2-9"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/sasl2/libsasldb.so.2.0.25",
+            "/usr/share/doc/libsasl2-modules-db/changelog.Debian.gz",
+            "/usr/share/doc/libsasl2-modules-db/copyright"
+          ]
+        },
+        {
+          "ID": "libseccomp2@2.6.0-2",
+          "Name": "libseccomp2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libseccomp2@2.6.0-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "f6e9daa8e2a1900f"
+          },
+          "Version": "2.6.0",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libseccomp",
+          "SrcVersion": "2.6.0",
+          "SrcRelease": "2",
+          "Licenses": [
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Kees Cook \u003ckees@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libseccomp.so.2.6.0",
+            "/usr/share/doc/libseccomp2/changelog.Debian.gz",
+            "/usr/share/doc/libseccomp2/changelog.gz",
+            "/usr/share/doc/libseccomp2/copyright"
+          ]
+        },
+        {
+          "ID": "libselinux1@3.8.1-1",
+          "Name": "libselinux1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libselinux1@3.8.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6273b1762ccaef9"
+          },
+          "Version": "3.8.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "libselinux",
+          "SrcVersion": "3.8.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "public-domain",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian SELinux maintainers \u003cselinux-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libpcre2-8-0@10.46-1~deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/tmpfiles.d/libselinux1.conf",
+            "/usr/lib/x86_64-linux-gnu/libselinux.so.1",
+            "/usr/share/doc/libselinux1/changelog.Debian.gz",
+            "/usr/share/doc/libselinux1/copyright"
+          ]
+        },
+        {
+          "ID": "libsemanage-common@3.8.1-1",
+          "Name": "libsemanage-common",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsemanage-common@3.8.1-1?arch=all\u0026distro=debian-13.1",
+            "UID": "82e27fcff653c8e2"
+          },
+          "Version": "3.8.1",
+          "Release": "1",
+          "Arch": "all",
+          "SrcName": "libsemanage",
+          "SrcVersion": "3.8.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "LGPL-2.1-only",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian SELinux maintainers \u003cselinux-devel@lists.alioth.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/libsemanage-common/changelog.Debian.gz",
+            "/usr/share/doc/libsemanage-common/copyright",
+            "/usr/share/man/man5/semanage.conf.5.gz"
+          ]
+        },
+        {
+          "ID": "libsemanage2@3.8.1-1",
+          "Name": "libsemanage2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsemanage2@3.8.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a2f1e5a679948b47"
+          },
+          "Version": "3.8.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "libsemanage",
+          "SrcVersion": "3.8.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "LGPL-2.1-only",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Debian SELinux maintainers \u003cselinux-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libaudit1@1:4.0.2-2+b2",
+            "libbz2-1.0@1.0.8-6",
+            "libc6@2.41-12",
+            "libselinux1@3.8.1-1",
+            "libsemanage-common@3.8.1-1",
+            "libsepol2@3.8.1-1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsemanage.so.2",
+            "/usr/share/doc/libsemanage2/changelog.Debian.gz",
+            "/usr/share/doc/libsemanage2/copyright"
+          ]
+        },
+        {
+          "ID": "libsepol2@3.8.1-1",
+          "Name": "libsepol2",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsepol2@3.8.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42060046fe7e6042"
+          },
+          "Version": "3.8.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "libsepol",
+          "SrcVersion": "3.8.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "LGPL-2.1-only",
+            "Zlib",
+            "GPL-2.0-only",
+            "GPL-2.0-or-later"
+          ],
+          "Maintainer": "Debian SELinux maintainers \u003cselinux-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsepol.so.2",
+            "/usr/share/doc/libsepol2/changelog.Debian.gz",
+            "/usr/share/doc/libsepol2/copyright"
+          ]
+        },
+        {
+          "ID": "libsmartcols1@2.41-5",
+          "Name": "libsmartcols1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsmartcols1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bdd963006efde917"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsmartcols.so.1.1.0",
+            "/usr/share/doc/libsmartcols1/NEWS.Debian.gz",
+            "/usr/share/doc/libsmartcols1/changelog.Debian.gz",
+            "/usr/share/doc/libsmartcols1/changelog.gz",
+            "/usr/share/doc/libsmartcols1/copyright",
+            "/usr/share/lintian/overrides/libsmartcols1"
+          ]
+        },
+        {
+          "ID": "libsqlite3-0@3.46.1-7",
+          "Name": "libsqlite3-0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsqlite3-0@3.46.1-7?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d3b12dcb7bd33f74"
+          },
+          "Version": "3.46.1",
+          "Release": "7",
+          "Arch": "amd64",
+          "SrcName": "sqlite3",
+          "SrcVersion": "3.46.1",
+          "SrcRelease": "7",
+          "Licenses": [
+            "public-domain",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Laszlo Boszormenyi (GCS) \u003cgcs@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6",
+            "/usr/share/doc/libsqlite3-0/README.Debian",
+            "/usr/share/doc/libsqlite3-0/changelog.Debian.gz",
+            "/usr/share/doc/libsqlite3-0/changelog.gz",
+            "/usr/share/doc/libsqlite3-0/changelog.html.gz",
+            "/usr/share/doc/libsqlite3-0/copyright"
+          ]
+        },
+        {
+          "ID": "libssh2-1t64@1.11.1-1",
+          "Name": "libssh2-1t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libssh2-1t64@1.11.1-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "9616552c195ea52b"
+          },
+          "Version": "1.11.1",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "libssh2",
+          "SrcVersion": "1.11.1",
+          "SrcRelease": "1",
+          "Licenses": [
+            "BSD-3-Clause",
+            "ISC"
+          ],
+          "Maintainer": "Nicolas Mora \u003cbabelouest@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libssl3t64@3.5.1-1+deb13u1",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1",
+            "/usr/share/doc/libssh2-1t64/AUTHORS",
+            "/usr/share/doc/libssh2-1t64/RELEASE-NOTES.gz",
+            "/usr/share/doc/libssh2-1t64/changelog.Debian.gz",
+            "/usr/share/doc/libssh2-1t64/changelog.gz",
+            "/usr/share/doc/libssh2-1t64/copyright"
+          ]
+        },
+        {
+          "ID": "libssl3t64@3.5.1-1+deb13u1",
+          "Name": "libssl3t64",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libssl3t64@3.5.1-1%2Bdeb13u1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "21570f13e9c95536"
+          },
+          "Version": "3.5.1",
+          "Release": "1+deb13u1",
+          "Arch": "amd64",
+          "SrcName": "openssl",
+          "SrcVersion": "3.5.1",
+          "SrcRelease": "1+deb13u1",
+          "Licenses": [
+            "Apache-2.0",
+            "Artistic-2.0",
+            "GPL-1.0-or-later",
+            "GPL-1.0-only"
+          ],
+          "Maintainer": "Debian OpenSSL Team \u003cpkg-openssl-devel@alioth-lists.debian.net\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libzstd1@1.5.7+dfsg-1",
+            "openssl-provider-legacy@3.5.1-1+deb13u1",
+            "zlib1g@1:1.3.dfsg+really1.3.1-1+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/engines-3/afalg.so",
+            "/usr/lib/x86_64-linux-gnu/engines-3/loader_attic.so",
+            "/usr/lib/x86_64-linux-gnu/engines-3/padlock.so",
+            "/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
+            "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+            "/usr/share/doc/libssl3t64/NEWS.Debian.gz",
+            "/usr/share/doc/libssl3t64/changelog.Debian.gz",
+            "/usr/share/doc/libssl3t64/changelog.gz",
+            "/usr/share/doc/libssl3t64/copyright",
+            "/usr/share/lintian/overrides/libssl3t64"
+          ]
+        },
+        {
+          "ID": "libstdc++6@14.2.0-19",
+          "Name": "libstdc++6",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libstdc%2B%2B6@14.2.0-19?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a2daa0680bfc657d"
+          },
+          "Version": "14.2.0",
+          "Release": "19",
+          "Arch": "amd64",
+          "SrcName": "gcc-14",
+          "SrcVersion": "14.2.0",
+          "SrcRelease": "19",
+          "Maintainer": "Debian GCC Maintainers \u003cdebian-gcc@lists.debian.org\u003e",
+          "DependsOn": [
+            "gcc-14-base@14.2.0-19",
+            "libc6@2.41-12",
+            "libgcc-s1@14.2.0-19"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33",
+            "/usr/share/gcc/python/libstdcxx/__init__.py",
+            "/usr/share/gcc/python/libstdcxx/v6/__init__.py",
+            "/usr/share/gcc/python/libstdcxx/v6/printers.py",
+            "/usr/share/gcc/python/libstdcxx/v6/xmethods.py",
+            "/usr/share/gdb/auto-load/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33-gdb.py"
+          ]
+        },
+        {
+          "ID": "libsystemd0@257.8-1~deb13u2",
+          "Name": "libsystemd0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libsystemd0@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b19608333503a8c4"
+          },
+          "Version": "257.8",
+          "Release": "1~deb13u2",
+          "Arch": "amd64",
+          "SrcName": "systemd",
+          "SrcVersion": "257.8",
+          "SrcRelease": "1~deb13u2",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "CC0-1.0",
+            "GPL-2 with Linux-syscall-note exception",
+            "MIT",
+            "public-domain",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Debian systemd Maintainers \u003cpkg-systemd-maintainers@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libcap2@1:2.75-10+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libsystemd.so.0.40.0",
+            "/usr/share/doc/libsystemd0/NEWS.Debian.gz",
+            "/usr/share/doc/libsystemd0/changelog.Debian.gz",
+            "/usr/share/doc/libsystemd0/copyright"
+          ]
+        },
+        {
+          "ID": "libtasn1-6@4.20.0-2",
+          "Name": "libtasn1-6",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libtasn1-6@4.20.0-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d8be543e1e2c465b"
+          },
+          "Version": "4.20.0",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libtasn1-6",
+          "SrcVersion": "4.20.0",
+          "SrcRelease": "2",
+          "Licenses": [
+            "LGPL-2.0-or-later",
+            "LGPL-2.1-only",
+            "GPL-3.0-only",
+            "GFDL-1.3-only"
+          ],
+          "Maintainer": "Debian GnuTLS Maintainers \u003cpkg-gnutls-maint@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.4",
+            "/usr/share/doc/libtasn1-6/AUTHORS",
+            "/usr/share/doc/libtasn1-6/README.md",
+            "/usr/share/doc/libtasn1-6/THANKS",
+            "/usr/share/doc/libtasn1-6/changelog.Debian.gz",
+            "/usr/share/doc/libtasn1-6/changelog.gz",
+            "/usr/share/doc/libtasn1-6/copyright"
+          ]
+        },
+        {
+          "ID": "libtinfo6@6.5+20250216-2",
+          "Name": "libtinfo6",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libtinfo6@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "39109c87ce11f4ff"
+          },
+          "Version": "6.5+20250216",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "ncurses",
+          "SrcVersion": "6.5+20250216",
+          "SrcRelease": "2",
+          "Licenses": [
+            "MIT/X11",
+            "X11",
+            "BSD-3-Clause"
+          ],
+          "Maintainer": "Ncurses Maintainers \u003cncurses@packages.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libtic.so.6.5",
+            "/usr/lib/x86_64-linux-gnu/libtinfo.so.6.5",
+            "/usr/share/doc/libtinfo6/changelog.Debian.gz",
+            "/usr/share/doc/libtinfo6/changelog.gz",
+            "/usr/share/doc/libtinfo6/copyright"
+          ]
+        },
+        {
+          "ID": "libudev1@257.8-1~deb13u2",
+          "Name": "libudev1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libudev1@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1a4e2b5bbb145a62"
+          },
+          "Version": "257.8",
+          "Release": "1~deb13u2",
+          "Arch": "amd64",
+          "SrcName": "systemd",
+          "SrcVersion": "257.8",
+          "SrcRelease": "1~deb13u2",
+          "Licenses": [
+            "LGPL-2.1-or-later",
+            "CC0-1.0",
+            "GPL-2 with Linux-syscall-note exception",
+            "MIT",
+            "public-domain",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Debian systemd Maintainers \u003cpkg-systemd-maintainers@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libcap2@1:2.75-10+b1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libudev.so.1.7.10",
+            "/usr/share/doc/libudev1/NEWS.Debian.gz",
+            "/usr/share/doc/libudev1/changelog.Debian.gz",
+            "/usr/share/doc/libudev1/copyright"
+          ]
+        },
+        {
+          "ID": "libunistring5@1.3-2",
+          "Name": "libunistring5",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libunistring5@1.3-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b6f656f97b0ff62"
+          },
+          "Version": "1.3",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "libunistring",
+          "SrcVersion": "1.3",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "LGPL-3.0-or-later",
+            "LGPL-2.0-or-later",
+            "GFDL-1.3-or-later",
+            "GFDL-1.2-or-later",
+            "LGPL-3.0-only",
+            "LGPL-2.1-or-later",
+            "BSD-3-Clause",
+            "ISC",
+            "Unicode-DFS-2016",
+            "public-domain",
+            "FreeSoftware",
+            "GPL-2.0-or-later",
+            "GPL-2+ with distribution exception",
+            "MIT",
+            "X11",
+            "GPL-3.0-only",
+            "GPL-2.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Jörg Frings-Fürst \u003cdebian@jff.email\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libunistring.so.5.2.0",
+            "/usr/share/doc/libunistring5/changelog.Debian.gz",
+            "/usr/share/doc/libunistring5/changelog.gz",
+            "/usr/share/doc/libunistring5/copyright"
+          ]
+        },
+        {
+          "ID": "libuuid1@2.41-5",
+          "Name": "libuuid1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libuuid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e68ae51900aac46d"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libuuid.so.1.3.0",
+            "/usr/share/doc/libuuid1/NEWS.Debian.gz",
+            "/usr/share/doc/libuuid1/changelog.Debian.gz",
+            "/usr/share/doc/libuuid1/changelog.gz",
+            "/usr/share/doc/libuuid1/copyright"
+          ]
+        },
+        {
+          "ID": "libxxhash0@0.8.3-2",
+          "Name": "libxxhash0",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libxxhash0@0.8.3-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ff44a1ed58690c52"
+          },
+          "Version": "0.8.3",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "xxhash",
+          "SrcVersion": "0.8.3",
+          "SrcRelease": "2",
+          "Licenses": [
+            "BSD-2-Clause",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Josue Ortega \u003cjosue@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libxxhash.so.0.8.3",
+            "/usr/share/doc/libxxhash0/changelog.Debian.gz",
+            "/usr/share/doc/libxxhash0/changelog.gz",
+            "/usr/share/doc/libxxhash0/copyright"
+          ]
+        },
+        {
+          "ID": "libzstd1@1.5.7+dfsg-1",
+          "Name": "libzstd1",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libzstd1@1.5.7%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6ca892087d90a628"
+          },
+          "Version": "1.5.7+dfsg",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "libzstd",
+          "SrcVersion": "1.5.7+dfsg",
+          "SrcRelease": "1",
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-2.0-only",
+            "Zlib",
+            "MIT"
+          ],
+          "Maintainer": "RPM packaging team \u003cteam+pkg-rpm@tracker.debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libzstd.so.1.5.7",
+            "/usr/share/doc/libzstd1/changelog.Debian.gz",
+            "/usr/share/doc/libzstd1/changelog.gz",
+            "/usr/share/doc/libzstd1/copyright"
+          ]
+        },
+        {
+          "ID": "login@1:4.16.0-2+really2.41-5",
+          "Name": "login",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/login@4.16.0-2%2Breally2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "9a6da06303db8b93"
+          },
+          "Version": "4.16.0-2+really2.41",
+          "Release": "5",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "DependsOn": [
+            "libaudit1@1:4.0.2-2+b2",
+            "libc6@2.41-12",
+            "libcrypt1@1:4.4.38-1",
+            "libpam-modules@1.7.0-5",
+            "libpam-runtime@1.7.0-5",
+            "libpam0g@1.7.0-5"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/login",
+            "/usr/bin/newgrp",
+            "/usr/sbin/nologin",
+            "/usr/share/bash-completion/completions/newgrp",
+            "/usr/share/doc/login/NEWS.Debian.gz",
+            "/usr/share/doc/login/changelog.Debian.gz",
+            "/usr/share/doc/login/changelog.gz",
+            "/usr/share/doc/login/copyright",
+            "/usr/share/lintian/overrides/login",
+            "/usr/share/man/de/man1/login.1.gz",
+            "/usr/share/man/de/man8/nologin.8.gz",
+            "/usr/share/man/fr/man1/login.1.gz",
+            "/usr/share/man/man1/login.1.gz",
+            "/usr/share/man/man1/newgrp.1.gz",
+            "/usr/share/man/man8/nologin.8.gz",
+            "/usr/share/man/pl/man1/login.1.gz",
+            "/usr/share/man/pl/man1/newgrp.1.gz",
+            "/usr/share/man/pl/man8/nologin.8.gz",
+            "/usr/share/man/ro/man1/login.1.gz",
+            "/usr/share/man/ro/man1/newgrp.1.gz",
+            "/usr/share/man/ro/man8/nologin.8.gz",
+            "/usr/share/man/sr/man1/login.1.gz",
+            "/usr/share/man/sr/man8/nologin.8.gz",
+            "/usr/share/man/uk/man1/login.1.gz",
+            "/usr/share/man/uk/man1/newgrp.1.gz",
+            "/usr/share/man/uk/man8/nologin.8.gz"
+          ]
+        },
+        {
+          "ID": "login.defs@1:4.17.4-2",
+          "Name": "login.defs",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/login.defs@4.17.4-2?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "b2ebc9108569350a"
+          },
+          "Version": "4.17.4",
+          "Release": "2",
+          "Epoch": 1,
+          "Arch": "all",
+          "SrcName": "shadow",
+          "SrcVersion": "4.17.4",
+          "SrcRelease": "2",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-1.0-only",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Shadow package maintainers \u003cpkg-shadow-devel@lists.alioth.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/login.defs/NEWS.Debian.gz",
+            "/usr/share/doc/login.defs/changelog.Debian.gz",
+            "/usr/share/doc/login.defs/changelog.gz",
+            "/usr/share/doc/login.defs/copyright",
+            "/usr/share/man/de/man5/login.defs.5.gz",
+            "/usr/share/man/fr/man5/login.defs.5.gz",
+            "/usr/share/man/it/man5/login.defs.5.gz",
+            "/usr/share/man/ja/man5/login.defs.5.gz",
+            "/usr/share/man/man5/login.defs.5.gz",
+            "/usr/share/man/ru/man5/login.defs.5.gz",
+            "/usr/share/man/uk/man5/login.defs.5.gz",
+            "/usr/share/man/zh_CN/man5/login.defs.5.gz"
+          ]
+        },
+        {
+          "ID": "mawk@1.3.4.20250131-1",
+          "Name": "mawk",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/mawk@1.3.4.20250131-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bea9bf7f923106e2"
+          },
+          "Version": "1.3.4.20250131",
+          "Release": "1",
+          "Arch": "amd64",
+          "SrcName": "mawk",
+          "SrcVersion": "1.3.4.20250131",
+          "SrcRelease": "1",
+          "Licenses": [
+            "GPL-2.0-only",
+            "X11",
+            "CC-BY-3.0"
+          ],
+          "Maintainer": "Boyuan Yang \u003cbyang@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/mawk",
+            "/usr/share/doc/mawk/ACKNOWLEDGMENT",
+            "/usr/share/doc/mawk/README",
+            "/usr/share/doc/mawk/changelog.Debian.gz",
+            "/usr/share/doc/mawk/changelog.gz",
+            "/usr/share/doc/mawk/copyright",
+            "/usr/share/doc/mawk/examples/ct_length.awk",
+            "/usr/share/doc/mawk/examples/decl.awk",
+            "/usr/share/doc/mawk/examples/deps.awk",
+            "/usr/share/doc/mawk/examples/eatc.awk",
+            "/usr/share/doc/mawk/examples/gdecl.awk",
+            "/usr/share/doc/mawk/examples/hcal",
+            "/usr/share/doc/mawk/examples/hical",
+            "/usr/share/doc/mawk/examples/nocomment.awk",
+            "/usr/share/doc/mawk/examples/primes.awk",
+            "/usr/share/doc/mawk/examples/qsort.awk",
+            "/usr/share/man/man1/mawk.1.gz",
+            "/usr/share/man/man7/mawk-arrays.7.gz",
+            "/usr/share/man/man7/mawk-code.7.gz"
+          ]
+        },
+        {
+          "ID": "mount@2.41-5",
+          "Name": "mount",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/mount@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c6fdc5cf989db569"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/mount",
+            "/usr/bin/umount",
+            "/usr/sbin/losetup",
+            "/usr/sbin/swapoff",
+            "/usr/sbin/swapon",
+            "/usr/share/bash-completion/completions/losetup",
+            "/usr/share/bash-completion/completions/mount",
+            "/usr/share/bash-completion/completions/swapoff",
+            "/usr/share/bash-completion/completions/swapon",
+            "/usr/share/bash-completion/completions/umount",
+            "/usr/share/doc/mount/NEWS.Debian.gz",
+            "/usr/share/doc/mount/changelog.Debian.gz",
+            "/usr/share/doc/mount/changelog.gz",
+            "/usr/share/doc/mount/copyright",
+            "/usr/share/doc/mount/examples/filesystems",
+            "/usr/share/doc/mount/examples/fstab",
+            "/usr/share/doc/mount/examples/mount.fstab",
+            "/usr/share/doc/mount/mount.txt",
+            "/usr/share/lintian/overrides/mount",
+            "/usr/share/man/man5/fstab.5.gz",
+            "/usr/share/man/man8/losetup.8.gz",
+            "/usr/share/man/man8/mount.8.gz",
+            "/usr/share/man/man8/swapon.8.gz",
+            "/usr/share/man/man8/umount.8.gz"
+          ]
+        },
+        {
+          "ID": "ncurses-base@6.5+20250216-2",
+          "Name": "ncurses-base",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/ncurses-base@6.5%2B20250216-2?arch=all\u0026distro=debian-13.1",
+            "UID": "76a1fb5936f344dc"
+          },
+          "Version": "6.5+20250216",
+          "Release": "2",
+          "Arch": "all",
+          "SrcName": "ncurses",
+          "SrcVersion": "6.5+20250216",
+          "SrcRelease": "2",
+          "Licenses": [
+            "MIT/X11",
+            "X11",
+            "BSD-3-Clause"
+          ],
+          "Maintainer": "Ncurses Maintainers \u003cncurses@packages.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/ncurses-base/FAQ",
+            "/usr/share/doc/ncurses-base/TODO.Debian",
+            "/usr/share/doc/ncurses-base/changelog.Debian.gz",
+            "/usr/share/doc/ncurses-base/changelog.gz",
+            "/usr/share/doc/ncurses-base/copyright",
+            "/usr/share/lintian/overrides/ncurses-base",
+            "/usr/share/tabset/std",
+            "/usr/share/tabset/stdcrt",
+            "/usr/share/tabset/vt100",
+            "/usr/share/tabset/vt300",
+            "/usr/share/terminfo/E/Eterm",
+            "/usr/share/terminfo/a/ansi",
+            "/usr/share/terminfo/c/cons25",
+            "/usr/share/terminfo/c/cygwin",
+            "/usr/share/terminfo/d/dumb",
+            "/usr/share/terminfo/h/hurd",
+            "/usr/share/terminfo/l/linux",
+            "/usr/share/terminfo/m/mach",
+            "/usr/share/terminfo/m/mach-bold",
+            "/usr/share/terminfo/m/mach-color",
+            "/usr/share/terminfo/m/mach-gnu",
+            "/usr/share/terminfo/m/mach-gnu-color",
+            "/usr/share/terminfo/p/pcansi",
+            "/usr/share/terminfo/r/rxvt",
+            "/usr/share/terminfo/r/rxvt-basic",
+            "/usr/share/terminfo/r/rxvt-unicode",
+            "/usr/share/terminfo/r/rxvt-unicode-256color",
+            "/usr/share/terminfo/s/screen",
+            "/usr/share/terminfo/s/screen-256color",
+            "/usr/share/terminfo/s/screen-256color-bce",
+            "/usr/share/terminfo/s/screen-bce",
+            "/usr/share/terminfo/s/screen-s",
+            "/usr/share/terminfo/s/screen-w",
+            "/usr/share/terminfo/s/screen.xterm-256color",
+            "/usr/share/terminfo/s/sun",
+            "/usr/share/terminfo/t/tmux",
+            "/usr/share/terminfo/t/tmux-256color",
+            "/usr/share/terminfo/v/vt100",
+            "/usr/share/terminfo/v/vt102",
+            "/usr/share/terminfo/v/vt220",
+            "/usr/share/terminfo/v/vt52",
+            "/usr/share/terminfo/w/wsvt25",
+            "/usr/share/terminfo/w/wsvt25m",
+            "/usr/share/terminfo/x/xterm",
+            "/usr/share/terminfo/x/xterm-256color",
+            "/usr/share/terminfo/x/xterm-color",
+            "/usr/share/terminfo/x/xterm-mono",
+            "/usr/share/terminfo/x/xterm-r5",
+            "/usr/share/terminfo/x/xterm-r6",
+            "/usr/share/terminfo/x/xterm-vt220",
+            "/usr/share/terminfo/x/xterm-xfree86"
+          ]
+        },
+        {
+          "ID": "ncurses-bin@6.5+20250216-2",
+          "Name": "ncurses-bin",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/ncurses-bin@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d03e89ad6a7a5243"
+          },
+          "Version": "6.5+20250216",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "ncurses",
+          "SrcVersion": "6.5+20250216",
+          "SrcRelease": "2",
+          "Licenses": [
+            "MIT/X11",
+            "X11",
+            "BSD-3-Clause"
+          ],
+          "Maintainer": "Ncurses Maintainers \u003cncurses@packages.debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/clear",
+            "/usr/bin/infocmp",
+            "/usr/bin/tabs",
+            "/usr/bin/tic",
+            "/usr/bin/toe",
+            "/usr/bin/tput",
+            "/usr/bin/tset",
+            "/usr/share/doc/ncurses-bin/changelog.Debian.gz",
+            "/usr/share/doc/ncurses-bin/changelog.gz",
+            "/usr/share/doc/ncurses-bin/copyright",
+            "/usr/share/man/man1/captoinfo.1.gz",
+            "/usr/share/man/man1/clear.1.gz",
+            "/usr/share/man/man1/infocmp.1.gz",
+            "/usr/share/man/man1/infotocap.1.gz",
+            "/usr/share/man/man1/tabs.1.gz",
+            "/usr/share/man/man1/tic.1.gz",
+            "/usr/share/man/man1/toe.1.gz",
+            "/usr/share/man/man1/tput.1.gz",
+            "/usr/share/man/man1/tset.1.gz",
+            "/usr/share/man/man5/scr_dump.5.gz",
+            "/usr/share/man/man5/term.5.gz",
+            "/usr/share/man/man5/terminfo.5.gz",
+            "/usr/share/man/man5/user_caps.5.gz",
+            "/usr/share/man/man7/term.7.gz"
+          ]
+        },
+        {
+          "ID": "netbase@6.5",
+          "Name": "netbase",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/netbase@6.5?arch=all\u0026distro=debian-13.1",
+            "UID": "b9a2c240e75fe15e"
+          },
+          "Version": "6.5",
+          "Arch": "all",
+          "SrcName": "netbase",
+          "SrcVersion": "6.5",
+          "Licenses": [
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Marco d'Itri \u003cmd@linux.it\u003e",
+          "Layer": {
+            "DiffID": "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/netbase/changelog.gz",
+            "/usr/share/doc/netbase/copyright"
+          ]
+        },
+        {
+          "ID": "openssl@3.5.1-1+deb13u1",
+          "Name": "openssl",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/openssl@3.5.1-1%2Bdeb13u1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d499b047116a6127"
+          },
+          "Version": "3.5.1",
+          "Release": "1+deb13u1",
+          "Arch": "amd64",
+          "SrcName": "openssl",
+          "SrcVersion": "3.5.1",
+          "SrcRelease": "1+deb13u1",
+          "Licenses": [
+            "Apache-2.0",
+            "Artistic-2.0",
+            "GPL-1.0-or-later",
+            "GPL-1.0-only"
+          ],
+          "Maintainer": "Debian OpenSSL Team \u003cpkg-openssl-devel@alioth-lists.debian.net\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:4f237755fbae41472cb9e0f874fa97abb8d684f8fdcc6bd485edc8b6267a9c93"
+          },
+          "InstalledFiles": [
+            "/usr/bin/c_rehash",
+            "/usr/bin/openssl",
+            "/usr/lib/ssl/misc/CA.pl",
+            "/usr/lib/ssl/misc/tsget.pl",
+            "/usr/share/doc/openssl/HOWTO/certificates.txt.gz",
+            "/usr/share/doc/openssl/HOWTO/documenting-functions-and-macros.md.gz",
+            "/usr/share/doc/openssl/HOWTO/keys.txt.gz",
+            "/usr/share/doc/openssl/NEWS.md.gz",
+            "/usr/share/doc/openssl/README-ENGINES.md.gz",
+            "/usr/share/doc/openssl/README-PROVIDERS.md.gz",
+            "/usr/share/doc/openssl/README-QUIC.md.gz",
+            "/usr/share/doc/openssl/README.Debian",
+            "/usr/share/doc/openssl/README.md.gz",
+            "/usr/share/doc/openssl/changelog.Debian.gz",
+            "/usr/share/doc/openssl/changelog.gz",
+            "/usr/share/doc/openssl/copyright",
+            "/usr/share/doc/openssl/fingerprints.txt",
+            "/usr/share/lintian/overrides/openssl",
+            "/usr/share/man/man1/CA.pl.1ssl.gz",
+            "/usr/share/man/man1/openssl-asn1parse.1ssl.gz",
+            "/usr/share/man/man1/openssl-ca.1ssl.gz",
+            "/usr/share/man/man1/openssl-ciphers.1ssl.gz",
+            "/usr/share/man/man1/openssl-cmds.1ssl.gz",
+            "/usr/share/man/man1/openssl-cmp.1ssl.gz",
+            "/usr/share/man/man1/openssl-cms.1ssl.gz",
+            "/usr/share/man/man1/openssl-crl.1ssl.gz",
+            "/usr/share/man/man1/openssl-crl2pkcs7.1ssl.gz",
+            "/usr/share/man/man1/openssl-dgst.1ssl.gz",
+            "/usr/share/man/man1/openssl-dhparam.1ssl.gz",
+            "/usr/share/man/man1/openssl-dsa.1ssl.gz",
+            "/usr/share/man/man1/openssl-dsaparam.1ssl.gz",
+            "/usr/share/man/man1/openssl-ec.1ssl.gz",
+            "/usr/share/man/man1/openssl-ecparam.1ssl.gz",
+            "/usr/share/man/man1/openssl-enc.1ssl.gz",
+            "/usr/share/man/man1/openssl-engine.1ssl.gz",
+            "/usr/share/man/man1/openssl-errstr.1ssl.gz",
+            "/usr/share/man/man1/openssl-fipsinstall.1ssl.gz",
+            "/usr/share/man/man1/openssl-format-options.1ssl.gz",
+            "/usr/share/man/man1/openssl-gendsa.1ssl.gz",
+            "/usr/share/man/man1/openssl-genpkey.1ssl.gz",
+            "/usr/share/man/man1/openssl-genrsa.1ssl.gz",
+            "/usr/share/man/man1/openssl-info.1ssl.gz",
+            "/usr/share/man/man1/openssl-kdf.1ssl.gz",
+            "/usr/share/man/man1/openssl-list.1ssl.gz",
+            "/usr/share/man/man1/openssl-mac.1ssl.gz",
+            "/usr/share/man/man1/openssl-namedisplay-options.1ssl.gz",
+            "/usr/share/man/man1/openssl-nseq.1ssl.gz",
+            "/usr/share/man/man1/openssl-ocsp.1ssl.gz",
+            "/usr/share/man/man1/openssl-passphrase-options.1ssl.gz",
+            "/usr/share/man/man1/openssl-passwd.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkcs12.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkcs7.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkcs8.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkey.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkeyparam.1ssl.gz",
+            "/usr/share/man/man1/openssl-pkeyutl.1ssl.gz",
+            "/usr/share/man/man1/openssl-prime.1ssl.gz",
+            "/usr/share/man/man1/openssl-rand.1ssl.gz",
+            "/usr/share/man/man1/openssl-rehash.1ssl.gz",
+            "/usr/share/man/man1/openssl-req.1ssl.gz",
+            "/usr/share/man/man1/openssl-rsa.1ssl.gz",
+            "/usr/share/man/man1/openssl-rsautl.1ssl.gz",
+            "/usr/share/man/man1/openssl-s_client.1ssl.gz",
+            "/usr/share/man/man1/openssl-s_server.1ssl.gz",
+            "/usr/share/man/man1/openssl-s_time.1ssl.gz",
+            "/usr/share/man/man1/openssl-sess_id.1ssl.gz",
+            "/usr/share/man/man1/openssl-skeyutl.1ssl.gz",
+            "/usr/share/man/man1/openssl-smime.1ssl.gz",
+            "/usr/share/man/man1/openssl-speed.1ssl.gz",
+            "/usr/share/man/man1/openssl-spkac.1ssl.gz",
+            "/usr/share/man/man1/openssl-srp.1ssl.gz",
+            "/usr/share/man/man1/openssl-storeutl.1ssl.gz",
+            "/usr/share/man/man1/openssl-ts.1ssl.gz",
+            "/usr/share/man/man1/openssl-verification-options.1ssl.gz",
+            "/usr/share/man/man1/openssl-verify.1ssl.gz",
+            "/usr/share/man/man1/openssl-version.1ssl.gz",
+            "/usr/share/man/man1/openssl-x509.1ssl.gz",
+            "/usr/share/man/man1/openssl.1ssl.gz",
+            "/usr/share/man/man1/tsget.1ssl.gz",
+            "/usr/share/man/man5/config.5ssl.gz",
+            "/usr/share/man/man5/fips_config.5ssl.gz",
+            "/usr/share/man/man5/x509v3_config.5ssl.gz",
+            "/usr/share/man/man7/EVP_ASYM_CIPHER-RSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_ASYM_CIPHER-SM2.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-AES.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-ARIA.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-BLOWFISH.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-CAMELLIA.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-CAST.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-CHACHA.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-DES.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-IDEA.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-NULL.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-RC2.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-RC4.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-RC5.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-SEED.7ssl.gz",
+            "/usr/share/man/man7/EVP_CIPHER-SM4.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-ARGON2.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-HKDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-HMAC-DRBG.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-KB.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-KRB5KDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-PBKDF1.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-PBKDF2.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-PKCS12KDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-PVKKDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-SCRYPT.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-SS.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-SSHKDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-TLS13_KDF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-TLS1_PRF.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-X942-ASN1.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-X942-CONCAT.7ssl.gz",
+            "/usr/share/man/man7/EVP_KDF-X963.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEM-EC.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEM-ML-KEM.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEM-RSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEM-X25519.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEYEXCH-DH.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEYEXCH-ECDH.7ssl.gz",
+            "/usr/share/man/man7/EVP_KEYEXCH-X25519.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-BLAKE2.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-CMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-GMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-HMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-KMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-Poly1305.7ssl.gz",
+            "/usr/share/man/man7/EVP_MAC-Siphash.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-BLAKE2.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-KECCAK.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-MD2.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-MD4.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-MD5-SHA1.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-MD5.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-MDC2.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-NULL.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-RIPEMD160.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-SHA1.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-SHA2.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-SHA3.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-SHAKE.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-SM3.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-WHIRLPOOL.7ssl.gz",
+            "/usr/share/man/man7/EVP_MD-common.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-DH.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-DSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-EC.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-FFC.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-HMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-ML-DSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-ML-KEM.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-RSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-SLH-DSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-SM2.7ssl.gz",
+            "/usr/share/man/man7/EVP_PKEY-X25519.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-CRNG-TEST.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-CTR-DRBG.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-HASH-DRBG.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-HMAC-DRBG.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-JITTER.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-SEED-SRC.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND-TEST-RAND.7ssl.gz",
+            "/usr/share/man/man7/EVP_RAND.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-DSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-ECDSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-ED25519.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-HMAC.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-ML-DSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-RSA.7ssl.gz",
+            "/usr/share/man/man7/EVP_SIGNATURE-SLH-DSA.7ssl.gz",
+            "/usr/share/man/man7/OSSL_PROVIDER-FIPS.7ssl.gz",
+            "/usr/share/man/man7/OSSL_PROVIDER-base.7ssl.gz",
+            "/usr/share/man/man7/OSSL_PROVIDER-default.7ssl.gz",
+            "/usr/share/man/man7/OSSL_PROVIDER-legacy.7ssl.gz",
+            "/usr/share/man/man7/OSSL_PROVIDER-null.7ssl.gz",
+            "/usr/share/man/man7/OSSL_STORE-winstore.7ssl.gz",
+            "/usr/share/man/man7/RAND.7ssl.gz",
+            "/usr/share/man/man7/RSA-PSS.7ssl.gz",
+            "/usr/share/man/man7/X25519.7ssl.gz",
+            "/usr/share/man/man7/bio.7ssl.gz",
+            "/usr/share/man/man7/ct.7ssl.gz",
+            "/usr/share/man/man7/des_modes.7ssl.gz",
+            "/usr/share/man/man7/evp.7ssl.gz",
+            "/usr/share/man/man7/fips_module.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-cipher.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-digest.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-kdf.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-mac.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-pkey.7ssl.gz",
+            "/usr/share/man/man7/life_cycle-rand.7ssl.gz",
+            "/usr/share/man/man7/openssl-core.h.7ssl.gz",
+            "/usr/share/man/man7/openssl-core_dispatch.h.7ssl.gz",
+            "/usr/share/man/man7/openssl-core_names.h.7ssl.gz",
+            "/usr/share/man/man7/openssl-env.7ssl.gz",
+            "/usr/share/man/man7/openssl-glossary.7ssl.gz",
+            "/usr/share/man/man7/openssl-qlog.7ssl.gz",
+            "/usr/share/man/man7/openssl-quic-concurrency.7ssl.gz",
+            "/usr/share/man/man7/openssl-quic.7ssl.gz",
+            "/usr/share/man/man7/openssl-threads.7ssl.gz",
+            "/usr/share/man/man7/openssl_user_macros.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-libcrypto-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-libraries-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-libssl-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-migration.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-client-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-client-non-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-multi-stream.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-server-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-quic-server-non-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-tls-client-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-tls-client-non-block.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-tls-introduction.7ssl.gz",
+            "/usr/share/man/man7/ossl-guide-tls-server-block.7ssl.gz",
+            "/usr/share/man/man7/ossl_store-file.7ssl.gz",
+            "/usr/share/man/man7/ossl_store.7ssl.gz",
+            "/usr/share/man/man7/passphrase-encoding.7ssl.gz",
+            "/usr/share/man/man7/property.7ssl.gz",
+            "/usr/share/man/man7/provider-asym_cipher.7ssl.gz",
+            "/usr/share/man/man7/provider-base.7ssl.gz",
+            "/usr/share/man/man7/provider-cipher.7ssl.gz",
+            "/usr/share/man/man7/provider-decoder.7ssl.gz",
+            "/usr/share/man/man7/provider-digest.7ssl.gz",
+            "/usr/share/man/man7/provider-encoder.7ssl.gz",
+            "/usr/share/man/man7/provider-kdf.7ssl.gz",
+            "/usr/share/man/man7/provider-kem.7ssl.gz",
+            "/usr/share/man/man7/provider-keyexch.7ssl.gz",
+            "/usr/share/man/man7/provider-keymgmt.7ssl.gz",
+            "/usr/share/man/man7/provider-mac.7ssl.gz",
+            "/usr/share/man/man7/provider-object.7ssl.gz",
+            "/usr/share/man/man7/provider-rand.7ssl.gz",
+            "/usr/share/man/man7/provider-signature.7ssl.gz",
+            "/usr/share/man/man7/provider-skeymgmt.7ssl.gz",
+            "/usr/share/man/man7/provider-storemgmt.7ssl.gz",
+            "/usr/share/man/man7/provider.7ssl.gz",
+            "/usr/share/man/man7/proxy-certificates.7ssl.gz",
+            "/usr/share/man/man7/x509.7ssl.gz"
+          ]
+        },
+        {
+          "ID": "openssl-provider-legacy@3.5.1-1+deb13u1",
+          "Name": "openssl-provider-legacy",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/openssl-provider-legacy@3.5.1-1%2Bdeb13u1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "8072c3a4dafcd517"
+          },
+          "Version": "3.5.1",
+          "Release": "1+deb13u1",
+          "Arch": "amd64",
+          "SrcName": "openssl",
+          "SrcVersion": "3.5.1",
+          "SrcRelease": "1+deb13u1",
+          "Licenses": [
+            "Apache-2.0",
+            "Artistic-2.0",
+            "GPL-1.0-or-later",
+            "GPL-1.0-only"
+          ],
+          "Maintainer": "Debian OpenSSL Team \u003cpkg-openssl-devel@alioth-lists.debian.net\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libssl3t64@3.5.1-1+deb13u1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/ossl-modules/legacy.so",
+            "/usr/share/doc/openssl-provider-legacy/changelog.Debian.gz",
+            "/usr/share/doc/openssl-provider-legacy/changelog.gz",
+            "/usr/share/doc/openssl-provider-legacy/copyright"
+          ]
+        },
+        {
+          "ID": "passwd@1:4.17.4-2",
+          "Name": "passwd",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/passwd@4.17.4-2?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "5e15080d1eeaf8e8"
+          },
+          "Version": "4.17.4",
+          "Release": "2",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "shadow",
+          "SrcVersion": "4.17.4",
+          "SrcRelease": "2",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "BSD-3-Clause",
+            "GPL-1.0-only",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Shadow package maintainers \u003cpkg-shadow-devel@lists.alioth.debian.org\u003e",
+          "DependsOn": [
+            "base-passwd@3.6.7",
+            "libacl1@2.3.2-2+b1",
+            "libattr1@1:2.5.2-3",
+            "libaudit1@1:4.0.2-2+b2",
+            "libbsd0@0.12.2-2",
+            "libc6@2.41-12",
+            "libcrypt1@1:4.4.38-1",
+            "libpam-modules@1.7.0-5",
+            "libpam0g@1.7.0-5",
+            "libselinux1@3.8.1-1",
+            "libsemanage2@3.8.1-1",
+            "login.defs@1:4.17.4-2"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/chage",
+            "/usr/bin/chfn",
+            "/usr/bin/chsh",
+            "/usr/bin/expiry",
+            "/usr/bin/gpasswd",
+            "/usr/bin/passwd",
+            "/usr/lib/tmpfiles.d/passwd.conf",
+            "/usr/sbin/chgpasswd",
+            "/usr/sbin/chpasswd",
+            "/usr/sbin/groupadd",
+            "/usr/sbin/groupdel",
+            "/usr/sbin/groupmod",
+            "/usr/sbin/grpck",
+            "/usr/sbin/grpconv",
+            "/usr/sbin/grpunconv",
+            "/usr/sbin/newusers",
+            "/usr/sbin/pwck",
+            "/usr/sbin/pwconv",
+            "/usr/sbin/pwunconv",
+            "/usr/sbin/shadowconfig",
+            "/usr/sbin/useradd",
+            "/usr/sbin/userdel",
+            "/usr/sbin/usermod",
+            "/usr/sbin/vipw",
+            "/usr/share/doc/passwd/NEWS.Debian.gz",
+            "/usr/share/doc/passwd/README.Debian",
+            "/usr/share/doc/passwd/TODO.Debian",
+            "/usr/share/doc/passwd/changelog.Debian.gz",
+            "/usr/share/doc/passwd/changelog.gz",
+            "/usr/share/doc/passwd/copyright",
+            "/usr/share/doc/passwd/examples/passwd.expire.cron",
+            "/usr/share/lintian/overrides/passwd",
+            "/usr/share/locale/bs/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/da/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/de/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/dz/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/el/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/es/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/he/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/id/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/it/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/kk/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/km/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ne/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/nn/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/sq/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/tl/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/shadow.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/shadow.mo",
+            "/usr/share/man/cs/man1/expiry.1.gz",
+            "/usr/share/man/cs/man1/gpasswd.1.gz",
+            "/usr/share/man/cs/man5/gshadow.5.gz",
+            "/usr/share/man/cs/man5/passwd.5.gz",
+            "/usr/share/man/cs/man5/shadow.5.gz",
+            "/usr/share/man/cs/man8/groupadd.8.gz",
+            "/usr/share/man/cs/man8/groupdel.8.gz",
+            "/usr/share/man/cs/man8/groupmod.8.gz",
+            "/usr/share/man/cs/man8/grpck.8.gz",
+            "/usr/share/man/cs/man8/vipw.8.gz",
+            "/usr/share/man/da/man1/chfn.1.gz",
+            "/usr/share/man/da/man5/gshadow.5.gz",
+            "/usr/share/man/da/man8/groupdel.8.gz",
+            "/usr/share/man/da/man8/vipw.8.gz",
+            "/usr/share/man/de/man1/chage.1.gz",
+            "/usr/share/man/de/man1/chfn.1.gz",
+            "/usr/share/man/de/man1/chsh.1.gz",
+            "/usr/share/man/de/man1/expiry.1.gz",
+            "/usr/share/man/de/man1/gpasswd.1.gz",
+            "/usr/share/man/de/man1/passwd.1.gz",
+            "/usr/share/man/de/man5/gshadow.5.gz",
+            "/usr/share/man/de/man5/passwd.5.gz",
+            "/usr/share/man/de/man5/shadow.5.gz",
+            "/usr/share/man/de/man8/chgpasswd.8.gz",
+            "/usr/share/man/de/man8/chpasswd.8.gz",
+            "/usr/share/man/de/man8/groupadd.8.gz",
+            "/usr/share/man/de/man8/groupdel.8.gz",
+            "/usr/share/man/de/man8/groupmod.8.gz",
+            "/usr/share/man/de/man8/grpck.8.gz",
+            "/usr/share/man/de/man8/newusers.8.gz",
+            "/usr/share/man/de/man8/pwck.8.gz",
+            "/usr/share/man/de/man8/pwconv.8.gz",
+            "/usr/share/man/de/man8/useradd.8.gz",
+            "/usr/share/man/de/man8/userdel.8.gz",
+            "/usr/share/man/de/man8/usermod.8.gz",
+            "/usr/share/man/de/man8/vipw.8.gz",
+            "/usr/share/man/fi/man1/chfn.1.gz",
+            "/usr/share/man/fi/man1/chsh.1.gz",
+            "/usr/share/man/fr/man1/chage.1.gz",
+            "/usr/share/man/fr/man1/chfn.1.gz",
+            "/usr/share/man/fr/man1/chsh.1.gz",
+            "/usr/share/man/fr/man1/expiry.1.gz",
+            "/usr/share/man/fr/man1/gpasswd.1.gz",
+            "/usr/share/man/fr/man1/passwd.1.gz",
+            "/usr/share/man/fr/man5/gshadow.5.gz",
+            "/usr/share/man/fr/man5/passwd.5.gz",
+            "/usr/share/man/fr/man5/shadow.5.gz",
+            "/usr/share/man/fr/man5/subgid.5.gz",
+            "/usr/share/man/fr/man5/subuid.5.gz",
+            "/usr/share/man/fr/man8/chgpasswd.8.gz",
+            "/usr/share/man/fr/man8/chpasswd.8.gz",
+            "/usr/share/man/fr/man8/groupadd.8.gz",
+            "/usr/share/man/fr/man8/groupdel.8.gz",
+            "/usr/share/man/fr/man8/groupmod.8.gz",
+            "/usr/share/man/fr/man8/grpck.8.gz",
+            "/usr/share/man/fr/man8/newusers.8.gz",
+            "/usr/share/man/fr/man8/pwck.8.gz",
+            "/usr/share/man/fr/man8/pwconv.8.gz",
+            "/usr/share/man/fr/man8/useradd.8.gz",
+            "/usr/share/man/fr/man8/userdel.8.gz",
+            "/usr/share/man/fr/man8/usermod.8.gz",
+            "/usr/share/man/fr/man8/vipw.8.gz",
+            "/usr/share/man/hu/man1/chsh.1.gz",
+            "/usr/share/man/hu/man1/gpasswd.1.gz",
+            "/usr/share/man/hu/man1/passwd.1.gz",
+            "/usr/share/man/hu/man5/passwd.5.gz",
+            "/usr/share/man/id/man1/chsh.1.gz",
+            "/usr/share/man/id/man8/useradd.8.gz",
+            "/usr/share/man/it/man1/chage.1.gz",
+            "/usr/share/man/it/man1/chfn.1.gz",
+            "/usr/share/man/it/man1/chsh.1.gz",
+            "/usr/share/man/it/man1/expiry.1.gz",
+            "/usr/share/man/it/man1/gpasswd.1.gz",
+            "/usr/share/man/it/man1/passwd.1.gz",
+            "/usr/share/man/it/man5/gshadow.5.gz",
+            "/usr/share/man/it/man5/passwd.5.gz",
+            "/usr/share/man/it/man5/shadow.5.gz",
+            "/usr/share/man/it/man8/chgpasswd.8.gz",
+            "/usr/share/man/it/man8/chpasswd.8.gz",
+            "/usr/share/man/it/man8/groupadd.8.gz",
+            "/usr/share/man/it/man8/groupdel.8.gz",
+            "/usr/share/man/it/man8/groupmod.8.gz",
+            "/usr/share/man/it/man8/grpck.8.gz",
+            "/usr/share/man/it/man8/newusers.8.gz",
+            "/usr/share/man/it/man8/pwck.8.gz",
+            "/usr/share/man/it/man8/pwconv.8.gz",
+            "/usr/share/man/it/man8/useradd.8.gz",
+            "/usr/share/man/it/man8/userdel.8.gz",
+            "/usr/share/man/it/man8/usermod.8.gz",
+            "/usr/share/man/it/man8/vipw.8.gz",
+            "/usr/share/man/ja/man1/chage.1.gz",
+            "/usr/share/man/ja/man1/chfn.1.gz",
+            "/usr/share/man/ja/man1/chsh.1.gz",
+            "/usr/share/man/ja/man1/expiry.1.gz",
+            "/usr/share/man/ja/man1/gpasswd.1.gz",
+            "/usr/share/man/ja/man1/passwd.1.gz",
+            "/usr/share/man/ja/man5/passwd.5.gz",
+            "/usr/share/man/ja/man5/shadow.5.gz",
+            "/usr/share/man/ja/man8/chpasswd.8.gz",
+            "/usr/share/man/ja/man8/groupadd.8.gz",
+            "/usr/share/man/ja/man8/groupdel.8.gz",
+            "/usr/share/man/ja/man8/groupmod.8.gz",
+            "/usr/share/man/ja/man8/grpck.8.gz",
+            "/usr/share/man/ja/man8/newusers.8.gz",
+            "/usr/share/man/ja/man8/pwck.8.gz",
+            "/usr/share/man/ja/man8/pwconv.8.gz",
+            "/usr/share/man/ja/man8/useradd.8.gz",
+            "/usr/share/man/ja/man8/userdel.8.gz",
+            "/usr/share/man/ja/man8/usermod.8.gz",
+            "/usr/share/man/ja/man8/vipw.8.gz",
+            "/usr/share/man/ko/man1/chfn.1.gz",
+            "/usr/share/man/ko/man1/chsh.1.gz",
+            "/usr/share/man/ko/man5/passwd.5.gz",
+            "/usr/share/man/ko/man8/vipw.8.gz",
+            "/usr/share/man/man1/chage.1.gz",
+            "/usr/share/man/man1/chfn.1.gz",
+            "/usr/share/man/man1/chsh.1.gz",
+            "/usr/share/man/man1/expiry.1.gz",
+            "/usr/share/man/man1/gpasswd.1.gz",
+            "/usr/share/man/man1/passwd.1.gz",
+            "/usr/share/man/man5/gshadow.5.gz",
+            "/usr/share/man/man5/passwd.5.gz",
+            "/usr/share/man/man5/shadow.5.gz",
+            "/usr/share/man/man5/subgid.5.gz",
+            "/usr/share/man/man5/subuid.5.gz",
+            "/usr/share/man/man8/chgpasswd.8.gz",
+            "/usr/share/man/man8/chpasswd.8.gz",
+            "/usr/share/man/man8/groupadd.8.gz",
+            "/usr/share/man/man8/groupdel.8.gz",
+            "/usr/share/man/man8/groupmod.8.gz",
+            "/usr/share/man/man8/grpck.8.gz",
+            "/usr/share/man/man8/newusers.8.gz",
+            "/usr/share/man/man8/pwck.8.gz",
+            "/usr/share/man/man8/pwconv.8.gz",
+            "/usr/share/man/man8/shadowconfig.8.gz",
+            "/usr/share/man/man8/useradd.8.gz",
+            "/usr/share/man/man8/userdel.8.gz",
+            "/usr/share/man/man8/usermod.8.gz",
+            "/usr/share/man/man8/vipw.8.gz",
+            "/usr/share/man/pl/man1/chage.1.gz",
+            "/usr/share/man/pl/man1/chsh.1.gz",
+            "/usr/share/man/pl/man1/expiry.1.gz",
+            "/usr/share/man/pl/man8/groupadd.8.gz",
+            "/usr/share/man/pl/man8/groupdel.8.gz",
+            "/usr/share/man/pl/man8/groupmod.8.gz",
+            "/usr/share/man/pl/man8/grpck.8.gz",
+            "/usr/share/man/pl/man8/userdel.8.gz",
+            "/usr/share/man/pl/man8/usermod.8.gz",
+            "/usr/share/man/pl/man8/vipw.8.gz",
+            "/usr/share/man/pt_BR/man1/gpasswd.1.gz",
+            "/usr/share/man/pt_BR/man5/passwd.5.gz",
+            "/usr/share/man/pt_BR/man5/shadow.5.gz",
+            "/usr/share/man/pt_BR/man8/groupadd.8.gz",
+            "/usr/share/man/pt_BR/man8/groupdel.8.gz",
+            "/usr/share/man/pt_BR/man8/groupmod.8.gz",
+            "/usr/share/man/ru/man1/chage.1.gz",
+            "/usr/share/man/ru/man1/chfn.1.gz",
+            "/usr/share/man/ru/man1/chsh.1.gz",
+            "/usr/share/man/ru/man1/expiry.1.gz",
+            "/usr/share/man/ru/man1/gpasswd.1.gz",
+            "/usr/share/man/ru/man1/passwd.1.gz",
+            "/usr/share/man/ru/man5/gshadow.5.gz",
+            "/usr/share/man/ru/man5/passwd.5.gz",
+            "/usr/share/man/ru/man5/shadow.5.gz",
+            "/usr/share/man/ru/man8/chgpasswd.8.gz",
+            "/usr/share/man/ru/man8/chpasswd.8.gz",
+            "/usr/share/man/ru/man8/groupadd.8.gz",
+            "/usr/share/man/ru/man8/groupdel.8.gz",
+            "/usr/share/man/ru/man8/groupmod.8.gz",
+            "/usr/share/man/ru/man8/grpck.8.gz",
+            "/usr/share/man/ru/man8/newusers.8.gz",
+            "/usr/share/man/ru/man8/pwck.8.gz",
+            "/usr/share/man/ru/man8/pwconv.8.gz",
+            "/usr/share/man/ru/man8/useradd.8.gz",
+            "/usr/share/man/ru/man8/userdel.8.gz",
+            "/usr/share/man/ru/man8/usermod.8.gz",
+            "/usr/share/man/ru/man8/vipw.8.gz",
+            "/usr/share/man/sv/man1/chage.1.gz",
+            "/usr/share/man/sv/man1/chsh.1.gz",
+            "/usr/share/man/sv/man1/expiry.1.gz",
+            "/usr/share/man/sv/man1/passwd.1.gz",
+            "/usr/share/man/sv/man5/gshadow.5.gz",
+            "/usr/share/man/sv/man5/passwd.5.gz",
+            "/usr/share/man/sv/man8/groupadd.8.gz",
+            "/usr/share/man/sv/man8/groupdel.8.gz",
+            "/usr/share/man/sv/man8/groupmod.8.gz",
+            "/usr/share/man/sv/man8/grpck.8.gz",
+            "/usr/share/man/sv/man8/pwck.8.gz",
+            "/usr/share/man/sv/man8/userdel.8.gz",
+            "/usr/share/man/sv/man8/vipw.8.gz",
+            "/usr/share/man/tr/man1/chage.1.gz",
+            "/usr/share/man/tr/man1/chfn.1.gz",
+            "/usr/share/man/tr/man1/passwd.1.gz",
+            "/usr/share/man/tr/man5/passwd.5.gz",
+            "/usr/share/man/tr/man5/shadow.5.gz",
+            "/usr/share/man/tr/man8/groupadd.8.gz",
+            "/usr/share/man/tr/man8/groupdel.8.gz",
+            "/usr/share/man/tr/man8/groupmod.8.gz",
+            "/usr/share/man/tr/man8/useradd.8.gz",
+            "/usr/share/man/tr/man8/userdel.8.gz",
+            "/usr/share/man/tr/man8/usermod.8.gz",
+            "/usr/share/man/uk/man1/chage.1.gz",
+            "/usr/share/man/uk/man1/chfn.1.gz",
+            "/usr/share/man/uk/man1/chsh.1.gz",
+            "/usr/share/man/uk/man1/expiry.1.gz",
+            "/usr/share/man/uk/man1/gpasswd.1.gz",
+            "/usr/share/man/uk/man1/passwd.1.gz",
+            "/usr/share/man/uk/man5/gshadow.5.gz",
+            "/usr/share/man/uk/man5/passwd.5.gz",
+            "/usr/share/man/uk/man5/shadow.5.gz",
+            "/usr/share/man/uk/man8/chgpasswd.8.gz",
+            "/usr/share/man/uk/man8/chpasswd.8.gz",
+            "/usr/share/man/uk/man8/groupadd.8.gz",
+            "/usr/share/man/uk/man8/groupdel.8.gz",
+            "/usr/share/man/uk/man8/groupmod.8.gz",
+            "/usr/share/man/uk/man8/grpck.8.gz",
+            "/usr/share/man/uk/man8/newusers.8.gz",
+            "/usr/share/man/uk/man8/pwck.8.gz",
+            "/usr/share/man/uk/man8/pwconv.8.gz",
+            "/usr/share/man/uk/man8/useradd.8.gz",
+            "/usr/share/man/uk/man8/userdel.8.gz",
+            "/usr/share/man/uk/man8/usermod.8.gz",
+            "/usr/share/man/uk/man8/vipw.8.gz",
+            "/usr/share/man/zh_CN/man1/chage.1.gz",
+            "/usr/share/man/zh_CN/man1/chfn.1.gz",
+            "/usr/share/man/zh_CN/man1/chsh.1.gz",
+            "/usr/share/man/zh_CN/man1/expiry.1.gz",
+            "/usr/share/man/zh_CN/man1/gpasswd.1.gz",
+            "/usr/share/man/zh_CN/man1/passwd.1.gz",
+            "/usr/share/man/zh_CN/man5/gshadow.5.gz",
+            "/usr/share/man/zh_CN/man5/passwd.5.gz",
+            "/usr/share/man/zh_CN/man5/shadow.5.gz",
+            "/usr/share/man/zh_CN/man8/chgpasswd.8.gz",
+            "/usr/share/man/zh_CN/man8/chpasswd.8.gz",
+            "/usr/share/man/zh_CN/man8/groupadd.8.gz",
+            "/usr/share/man/zh_CN/man8/groupdel.8.gz",
+            "/usr/share/man/zh_CN/man8/groupmod.8.gz",
+            "/usr/share/man/zh_CN/man8/grpck.8.gz",
+            "/usr/share/man/zh_CN/man8/newusers.8.gz",
+            "/usr/share/man/zh_CN/man8/pwck.8.gz",
+            "/usr/share/man/zh_CN/man8/pwconv.8.gz",
+            "/usr/share/man/zh_CN/man8/useradd.8.gz",
+            "/usr/share/man/zh_CN/man8/userdel.8.gz",
+            "/usr/share/man/zh_CN/man8/usermod.8.gz",
+            "/usr/share/man/zh_CN/man8/vipw.8.gz",
+            "/usr/share/man/zh_TW/man1/chfn.1.gz",
+            "/usr/share/man/zh_TW/man1/chsh.1.gz",
+            "/usr/share/man/zh_TW/man5/passwd.5.gz",
+            "/usr/share/man/zh_TW/man8/chpasswd.8.gz",
+            "/usr/share/man/zh_TW/man8/groupadd.8.gz",
+            "/usr/share/man/zh_TW/man8/groupdel.8.gz",
+            "/usr/share/man/zh_TW/man8/groupmod.8.gz",
+            "/usr/share/man/zh_TW/man8/useradd.8.gz",
+            "/usr/share/man/zh_TW/man8/userdel.8.gz",
+            "/usr/share/man/zh_TW/man8/usermod.8.gz"
+          ]
+        },
+        {
+          "ID": "perl-base@5.40.1-6",
+          "Name": "perl-base",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/perl-base@5.40.1-6?arch=amd64\u0026distro=debian-13.1",
+            "UID": "17f06da2c02a11c6"
+          },
+          "Version": "5.40.1",
+          "Release": "6",
+          "Arch": "amd64",
+          "SrcName": "perl",
+          "SrcVersion": "5.40.1",
+          "SrcRelease": "6",
+          "Licenses": [
+            "GPL-1.0-or-later",
+            "Artistic-2.0",
+            "MIT",
+            "REGCOMP",
+            "GPL-2.0-with-bison-exception+",
+            "Unicode",
+            "BZIP",
+            "Zlib",
+            "GPL-2.0-or-later",
+            "FSFAP",
+            "BSD-3-clause-with-weird-numbering",
+            "CC0-1.0",
+            "TEXT-TABS",
+            "BSD-4-clause-POWERDOG",
+            "BSD-3-clause-GENERIC",
+            "BSD-3-Clause",
+            "SDBM-PUBLIC-DOMAIN",
+            "DONT-CHANGE-THE-GPL",
+            "Artistic-dist",
+            "LGPL-2.1-only",
+            "GPL-1.0-only",
+            "GPL-2.0-only",
+            "Artistic-2"
+          ],
+          "Maintainer": "Niko Tyni \u003cntyni@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/perl",
+            "/usr/bin/perl5.40.1",
+            "/usr/lib/x86_64-linux-gnu/perl-base/AutoLoader.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Carp.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Carp/Heavy.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Config.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Config_git.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Config_heavy.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Cwd.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/DynaLoader.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Errno.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Exporter.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Exporter/Heavy.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Fcntl.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Basename.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Glob.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Path.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Spec.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Spec/Unix.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/File/Temp.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/FileHandle.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Getopt/Long.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Getopt/Long/Parser.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Hash/Util.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/File.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Handle.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Pipe.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Seekable.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Select.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Socket.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Socket/INET.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Socket/IP.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IO/Socket/UNIX.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IPC/Open2.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/IPC/Open3.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/List/Util.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/POSIX.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Scalar/Util.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/SelectSaver.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Socket.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Symbol.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Text/ParseWords.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Text/Tabs.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Text/Wrap.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/Tie/Hash.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/XSLoader.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/attributes.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/Cwd/Cwd.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/Fcntl/Fcntl.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/File/Glob/Glob.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/Hash/Util/Util.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/IO/IO.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/List/Util/Util.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/POSIX/POSIX.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/Socket/Socket.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/attributes/attributes.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/auto/re/re.so",
+            "/usr/lib/x86_64-linux-gnu/perl-base/base.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/builtin.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/bytes.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/constant.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/feature.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/fields.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/integer.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/lib.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/locale.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/overload.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/overloading.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/parent.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/re.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/strict.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Age.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Bc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Bmg.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Bpb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Bpt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Cf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Ea.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/EqUIdeo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/GCB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Gc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Hst.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Identif2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Identifi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/InPC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/InSC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Isc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Jg.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Jt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Lb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Lc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NFCQC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NFDQC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NFKCCF.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NFKCQC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NFKDQC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Na1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/NameAlia.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Nt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Nv.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/PerlDeci.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/SB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Sc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Scx.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Tc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Uc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/Vo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/WB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/_PerlLB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/To/_PerlSCX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/NA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V100.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V11.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V110.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V120.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V130.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V140.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V150.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V20.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V30.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V31.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V32.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V40.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V41.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V50.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V51.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V52.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V60.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V61.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V70.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V80.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Age/V90.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Alpha/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/AL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/AN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/B.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/BN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/CS.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/EN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/ES.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/ET.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/L.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/NSM.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/ON.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/R.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bc/WS.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/BidiC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/BidiM/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Blk/NB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bpt/C.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bpt/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Bpt/O.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CE/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CI/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWCF/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWCM/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWKCF/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWL/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWT/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CWU/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Cased/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/A.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/AL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/AR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/ATAR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/B.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/BR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/DB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/NK.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/NR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/OV.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ccc/VR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/CompEx/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/DI/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dash/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dep/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dia/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Com.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Enc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Fin.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Font.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Init.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Iso.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Med.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Nar.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Nb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/NonCanon.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Sqr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Sub.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Sup.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Dt/Vert.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/EBase/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/EComp/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/EPres/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ea/A.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ea/H.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ea/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ea/Na.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ea/W.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Emoji/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ext/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/ExtPict/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/CN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/EX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/LV.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/LVT.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/PP.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/SM.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GCB/XX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/C.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Cf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Cn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/L.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/LC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Ll.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Lm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Lo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Lu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/M.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Mc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Me.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Mn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Nd.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Nl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/No.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/P.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Pc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Pd.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Pe.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Pf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Pi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Po.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Ps.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/S.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Sc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Sk.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Sm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/So.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Z.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Gc/Zs.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GrBase/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/GrExt/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Hex/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Hst/NA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Hyphen/T.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IDC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IDS/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdStatus/Allowed.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdStatus/Restrict.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/DefaultI.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Exclusio.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Inclusio.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/LimitedU.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/NotChara.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/NotNFKC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/NotXID.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Obsolete.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Recommen.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Technica.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/IdType/Uncommon.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Ideo/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/10_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/11_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/12_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/12_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/13_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/14_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/15_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/2_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/2_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/3_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/3_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/3_2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/4_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/4_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/5_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/5_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/5_2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/6_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/6_1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/6_2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/6_3.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/7_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/8_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/In/9_0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/Bottom.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/BottomAn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/Left.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/LeftAndR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/NA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/Overstru.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/Right.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/Top.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/TopAndBo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/TopAndL2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/TopAndLe.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/TopAndRi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InPC/VisualOr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Avagraha.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Bindu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Cantilla.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona3.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona4.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona5.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona6.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona7.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona8.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consona9.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Consonan.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Geminati.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Invisibl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Nukta.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Number.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Other.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/PureKill.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Syllable.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/ToneMark.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Virama.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Visarga.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/Vowel.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/VowelDep.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/InSC/VowelInd.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Ain.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Alef.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Beh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Dal.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/FarsiYeh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Feh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Gaf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Hah.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/HanifiRo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Kaf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Lam.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/NoJoinin.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Noon.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Qaf.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Reh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Sad.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Seen.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Tah.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Waw.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jg/Yeh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/C.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/D.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/L.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/R.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/T.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Jt/U.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/AI.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/AL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/BA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/BB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/CJ.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/CL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/CM.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/EX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/GL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/ID.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/IN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/IS.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/NS.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/NU.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/OP.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/PO.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/PR.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/QU.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/SA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lb/XX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Lower/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Math/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFCQC/M.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFCQC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFDQC/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFDQC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFKCQC/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFKCQC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFKDQC/N.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/NFKDQC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nt/Di.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nt/None.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nt/Nu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/0.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/10.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/100.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/10000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/100000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/11.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/12.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/13.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/14.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/15.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/16.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/17.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/18.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/19.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_16.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_3.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_4.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_6.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/1_8.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/20.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/200.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/2000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/20000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/2_3.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/3.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/30.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/300.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/3000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/30000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/3_16.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/3_4.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/4.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/40.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/400.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/4000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/40000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/5.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/50.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/500.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/5000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/50000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/6.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/60.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/600.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/6000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/60000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/7.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/70.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/700.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/7000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/70000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/8.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/80.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/800.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/8000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/80000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/9.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/90.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/900.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/9000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Nv/90000.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/PCM/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/PatSyn/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Alnum.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Assigned.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Blank.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Graph.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/PerlWord.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/PosixPun.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Print.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/SpacePer.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Title.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/Word.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/XPosixPu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlAny.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlCh2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlCha.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlFol.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlIDC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlIDS.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlIsI.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlNch.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlPat.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlPr2.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlPro.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Perl/_PerlQuo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/QMark/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/AT.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/CL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/EX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/FO.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/LE.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/LO.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/NU.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/SC.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/ST.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/Sp.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/UP.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SB/XX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/SD/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/STerm/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Arab.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Beng.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Cprt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Cyrl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Deva.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Dupl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Geor.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Glag.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Gong.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Gonm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Gran.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Grek.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Gujr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Guru.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Han.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Hang.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Hira.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Kana.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Knda.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Latn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Limb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Linb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Mlym.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Mong.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Mult.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Orya.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Sinh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Syrc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Taml.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Telu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Zinh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Sc/Zyyy.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Adlm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Arab.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Armn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Beng.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Bhks.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Bopo.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Cakm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Cham.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Copt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Cprt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Cyrl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Deva.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Diak.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Dupl.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Ethi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Geor.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Glag.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Gong.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Gonm.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Gran.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Grek.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Gujr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Guru.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Han.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Hang.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Hebr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Hira.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Hmng.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Hmnp.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Kana.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Khar.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Khmr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Khoj.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Knda.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Kthi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Lana.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Lao.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Latn.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Limb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Lina.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Linb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Mlym.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Mong.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Mult.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Mymr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Nand.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Nko.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Orya.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Phlp.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Rohg.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Shrd.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Sind.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Sinh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Syrc.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Tagb.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Takr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Talu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Taml.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Tang.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Telu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Thaa.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Tibt.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Tirh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Vith.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Xsux.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Yezi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Yi.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Zinh.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Zyyy.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Scx/Zzzz.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Term/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/UIdeo/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Upper/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/VS/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Vo/R.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Vo/Tr.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Vo/Tu.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/Vo/U.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/EX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/Extend.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/FO.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/HL.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/KA.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/LE.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/MB.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/ML.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/MN.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/NU.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/WSegSpac.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/WB/XX.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/XIDC/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/unicore/lib/XIDS/Y.pl",
+            "/usr/lib/x86_64-linux-gnu/perl-base/utf8.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/vars.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/warnings.pm",
+            "/usr/lib/x86_64-linux-gnu/perl-base/warnings/register.pm",
+            "/usr/share/doc/perl-base/changelog.Debian.gz",
+            "/usr/share/doc/perl-base/changelog.gz",
+            "/usr/share/doc/perl-base/copyright",
+            "/usr/share/doc/perl/AUTHORS.gz",
+            "/usr/share/doc/perl/Documentation",
+            "/usr/share/lintian/overrides/perl-base",
+            "/usr/share/man/man1/perl.1.gz"
+          ]
+        },
+        {
+          "ID": "publicsuffix@20250328.1952-0.1",
+          "Name": "publicsuffix",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/publicsuffix@20250328.1952-0.1?arch=all\u0026distro=debian-13.1",
+            "UID": "3a26edf0ee7e35a"
+          },
+          "Version": "20250328.1952",
+          "Release": "0.1",
+          "Arch": "all",
+          "SrcName": "publicsuffix",
+          "SrcVersion": "20250328.1952",
+          "SrcRelease": "0.1",
+          "Licenses": [
+            "MPL-2.0",
+            "CC0-1.0"
+          ],
+          "Maintainer": "Daniel Kahn Gillmor \u003cdkg@fifthhorseman.net\u003e",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/publicsuffix/README.Debian",
+            "/usr/share/doc/publicsuffix/changelog.Debian.gz",
+            "/usr/share/doc/publicsuffix/changelog.gz",
+            "/usr/share/doc/publicsuffix/copyright",
+            "/usr/share/doc/publicsuffix/examples/test_psl.txt",
+            "/usr/share/publicsuffix/public_suffix_list.dafsa",
+            "/usr/share/publicsuffix/public_suffix_list.dat"
+          ]
+        },
+        {
+          "ID": "readline-common@8.2-6",
+          "Name": "readline-common",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/readline-common@8.2-6?arch=all\u0026distro=debian-13.1",
+            "UID": "2ef8ce2c5e541e0b"
+          },
+          "Version": "8.2",
+          "Release": "6",
+          "Arch": "all",
+          "SrcName": "readline",
+          "SrcVersion": "8.2",
+          "SrcRelease": "6",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GFDL-1.3-no-invariants-or-later",
+            "GFDL-1.3-or-later",
+            "ISC-no-attribution"
+          ],
+          "Maintainer": "Matthias Klose \u003cdoko@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/readline-common/changelog.Debian.gz",
+            "/usr/share/doc/readline-common/changelog.gz",
+            "/usr/share/doc/readline-common/copyright",
+            "/usr/share/doc/readline-common/inputrc.arrows",
+            "/usr/share/info/rluserman.info.gz",
+            "/usr/share/lintian/overrides/readline-common",
+            "/usr/share/man/man3/history.3readline.gz",
+            "/usr/share/man/man3/readline.3readline.gz",
+            "/usr/share/readline/inputrc"
+          ]
+        },
+        {
+          "ID": "sed@4.9-2",
+          "Name": "sed",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/sed@4.9-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b33d5e34015f5d69"
+          },
+          "Version": "4.9",
+          "Release": "2",
+          "Arch": "amd64",
+          "SrcName": "sed",
+          "SrcVersion": "4.9",
+          "SrcRelease": "2",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "X11",
+            "GFDL-1.3-no-invariants-or-later",
+            "GFDL-1.3-only",
+            "ISC",
+            "BSD-4-Clause-UC",
+            "BSL-1",
+            "pcre"
+          ],
+          "Maintainer": "Clint Adams \u003cclint@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/sed",
+            "/usr/share/doc/sed/AUTHORS",
+            "/usr/share/doc/sed/BUGS.gz",
+            "/usr/share/doc/sed/NEWS.gz",
+            "/usr/share/doc/sed/README",
+            "/usr/share/doc/sed/THANKS.gz",
+            "/usr/share/doc/sed/changelog.Debian.gz",
+            "/usr/share/doc/sed/changelog.gz",
+            "/usr/share/doc/sed/copyright",
+            "/usr/share/doc/sed/examples/dc.sed",
+            "/usr/share/doc/sed/sedfaq.txt.gz",
+            "/usr/share/info/sed.info.gz",
+            "/usr/share/locale/af/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ast/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/bg/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/da/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/de/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/el/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/es/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/et/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/he/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/id/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/it/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/sed.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/sed.mo",
+            "/usr/share/man/man1/sed.1.gz"
+          ]
+        },
+        {
+          "ID": "sqv@1.3.0-3",
+          "Name": "sqv",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/sqv@1.3.0-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ab6bad6083333bb9"
+          },
+          "Version": "1.3.0",
+          "Release": "3",
+          "Arch": "amd64",
+          "SrcName": "rust-sequoia-sqv",
+          "SrcVersion": "1.3.0",
+          "SrcRelease": "3",
+          "Licenses": [
+            "LGPL-2.0-or-later",
+            "LGPL-2.0-only"
+          ],
+          "Maintainer": "Debian Rust Maintainers \u003cpkg-rust-maintainers@alioth-lists.debian.net\u003e",
+          "DependsOn": [
+            "libc6@2.41-12",
+            "libgcc-s1@14.2.0-19",
+            "libgmp10@2:6.3.0+dfsg-3",
+            "libhogweed6t64@3.10.1-1",
+            "libnettle8t64@3.10.1-1"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/sqv",
+            "/usr/share/bash-completion/completions/sqv.bash",
+            "/usr/share/doc/sqv/NEWS.gz",
+            "/usr/share/doc/sqv/changelog.Debian.gz",
+            "/usr/share/doc/sqv/copyright",
+            "/usr/share/fish/completions/sqv.fish",
+            "/usr/share/man/man1/sqv.1.gz",
+            "/usr/share/zsh/vendor-completions/_sqv"
+          ]
+        },
+        {
+          "ID": "sysvinit-utils@3.14-4",
+          "Name": "sysvinit-utils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/sysvinit-utils@3.14-4?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c7e8999242a896a1"
+          },
+          "Version": "3.14",
+          "Release": "4",
+          "Arch": "amd64",
+          "SrcName": "sysvinit",
+          "SrcVersion": "3.14",
+          "SrcRelease": "4",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "LGPL-2.1-or-later",
+            "GPL-3.0-only",
+            "GPL-2.0-only",
+            "LGPL-2.1-only"
+          ],
+          "Maintainer": "Debian sysvinit maintainers \u003cdebian-init-diversity@chiark.greenend.org.uk\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/init/init-d-script",
+            "/usr/lib/init/vars.sh",
+            "/usr/lib/lsb/init-functions",
+            "/usr/lib/lsb/init-functions.d/00-verbose",
+            "/usr/sbin/fstab-decode",
+            "/usr/sbin/killall5",
+            "/usr/share/doc/sysvinit-utils/changelog.Debian.gz",
+            "/usr/share/doc/sysvinit-utils/copyright",
+            "/usr/share/man/man5/init-d-script.5.gz",
+            "/usr/share/man/man8/fstab-decode.8.gz",
+            "/usr/share/man/man8/killall5.8.gz",
+            "/usr/share/man/man8/pidof.8.gz"
+          ]
+        },
+        {
+          "ID": "tar@1.35+dfsg-3.1",
+          "Name": "tar",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/tar@1.35%2Bdfsg-3.1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "50aee76d081ea925"
+          },
+          "Version": "1.35+dfsg",
+          "Release": "3.1",
+          "Arch": "amd64",
+          "SrcName": "tar",
+          "SrcVersion": "1.35+dfsg",
+          "SrcRelease": "3.1",
+          "Licenses": [
+            "GPL-3.0-or-later",
+            "GPL-3.0-only",
+            "GPL-3+ with Bison exception",
+            "LGPL-2.1-or-later",
+            "LGPL-2.1-only",
+            "LGPL-3.0-or-later",
+            "LGPL-3.0-only",
+            "GPL-2.0-or-later",
+            "GPL-2.0-only"
+          ],
+          "Maintainer": "Janos Lenart \u003cocsi@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/tar",
+            "/usr/lib/mime/packages/tar",
+            "/usr/sbin/rmt-tar",
+            "/usr/sbin/tarcat",
+            "/usr/share/doc/tar/AUTHORS",
+            "/usr/share/doc/tar/NEWS.gz",
+            "/usr/share/doc/tar/README.Debian",
+            "/usr/share/doc/tar/THANKS.gz",
+            "/usr/share/doc/tar/changelog.1.gz",
+            "/usr/share/doc/tar/changelog.Debian.gz",
+            "/usr/share/doc/tar/changelog.gz",
+            "/usr/share/doc/tar/copyright",
+            "/usr/share/locale/bg/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ca/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/cs/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/da/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/de/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/el/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/eo/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/es/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/et/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/eu/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/fi/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/fr/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ga/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/gl/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/hr/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/hu/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/id/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/it/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ja/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ka/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ko/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ky/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ms/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/nb/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/nl/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/pl/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/pt/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/pt_BR/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ro/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/ru/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/sk/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/sl/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/sr/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/sv/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/tr/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/uk/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/vi/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/zh_CN/LC_MESSAGES/tar.mo",
+            "/usr/share/locale/zh_TW/LC_MESSAGES/tar.mo",
+            "/usr/share/man/man1/tar.1.gz",
+            "/usr/share/man/man1/tarcat.1.gz",
+            "/usr/share/man/man8/rmt-tar.8.gz"
+          ]
+        },
+        {
+          "ID": "tzdata@2025b-4+deb13u1",
+          "Name": "tzdata",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/tzdata@2025b-4%2Bdeb13u1?arch=all\u0026distro=debian-13.1",
+            "UID": "d92875c0b47c5838"
+          },
+          "Version": "2025b",
+          "Release": "4+deb13u1",
+          "Arch": "all",
+          "SrcName": "tzdata",
+          "SrcVersion": "2025b",
+          "SrcRelease": "4+deb13u1",
+          "Licenses": [
+            "public-domain"
+          ],
+          "Maintainer": "GNU Libc Maintainers \u003cdebian-glibc@lists.debian.org\u003e",
+          "DependsOn": [
+            "debconf@1.5.91"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/share/doc/tzdata/NEWS.Debian.gz",
+            "/usr/share/doc/tzdata/README.Debian",
+            "/usr/share/doc/tzdata/changelog.Debian.gz",
+            "/usr/share/doc/tzdata/changelog.gz",
+            "/usr/share/doc/tzdata/copyright",
+            "/usr/share/lintian/overrides/tzdata",
+            "/usr/share/zoneinfo/Africa/Abidjan",
+            "/usr/share/zoneinfo/Africa/Accra",
+            "/usr/share/zoneinfo/Africa/Addis_Ababa",
+            "/usr/share/zoneinfo/Africa/Algiers",
+            "/usr/share/zoneinfo/Africa/Asmara",
+            "/usr/share/zoneinfo/Africa/Bamako",
+            "/usr/share/zoneinfo/Africa/Bangui",
+            "/usr/share/zoneinfo/Africa/Banjul",
+            "/usr/share/zoneinfo/Africa/Bissau",
+            "/usr/share/zoneinfo/Africa/Blantyre",
+            "/usr/share/zoneinfo/Africa/Brazzaville",
+            "/usr/share/zoneinfo/Africa/Bujumbura",
+            "/usr/share/zoneinfo/Africa/Cairo",
+            "/usr/share/zoneinfo/Africa/Casablanca",
+            "/usr/share/zoneinfo/Africa/Ceuta",
+            "/usr/share/zoneinfo/Africa/Conakry",
+            "/usr/share/zoneinfo/Africa/Dakar",
+            "/usr/share/zoneinfo/Africa/Dar_es_Salaam",
+            "/usr/share/zoneinfo/Africa/Djibouti",
+            "/usr/share/zoneinfo/Africa/Douala",
+            "/usr/share/zoneinfo/Africa/El_Aaiun",
+            "/usr/share/zoneinfo/Africa/Freetown",
+            "/usr/share/zoneinfo/Africa/Gaborone",
+            "/usr/share/zoneinfo/Africa/Harare",
+            "/usr/share/zoneinfo/Africa/Johannesburg",
+            "/usr/share/zoneinfo/Africa/Juba",
+            "/usr/share/zoneinfo/Africa/Kampala",
+            "/usr/share/zoneinfo/Africa/Khartoum",
+            "/usr/share/zoneinfo/Africa/Kigali",
+            "/usr/share/zoneinfo/Africa/Kinshasa",
+            "/usr/share/zoneinfo/Africa/Lagos",
+            "/usr/share/zoneinfo/Africa/Libreville",
+            "/usr/share/zoneinfo/Africa/Lome",
+            "/usr/share/zoneinfo/Africa/Luanda",
+            "/usr/share/zoneinfo/Africa/Lubumbashi",
+            "/usr/share/zoneinfo/Africa/Lusaka",
+            "/usr/share/zoneinfo/Africa/Malabo",
+            "/usr/share/zoneinfo/Africa/Maputo",
+            "/usr/share/zoneinfo/Africa/Maseru",
+            "/usr/share/zoneinfo/Africa/Mbabane",
+            "/usr/share/zoneinfo/Africa/Mogadishu",
+            "/usr/share/zoneinfo/Africa/Monrovia",
+            "/usr/share/zoneinfo/Africa/Nairobi",
+            "/usr/share/zoneinfo/Africa/Ndjamena",
+            "/usr/share/zoneinfo/Africa/Niamey",
+            "/usr/share/zoneinfo/Africa/Nouakchott",
+            "/usr/share/zoneinfo/Africa/Ouagadougou",
+            "/usr/share/zoneinfo/Africa/Porto-Novo",
+            "/usr/share/zoneinfo/Africa/Sao_Tome",
+            "/usr/share/zoneinfo/Africa/Tripoli",
+            "/usr/share/zoneinfo/Africa/Tunis",
+            "/usr/share/zoneinfo/Africa/Windhoek",
+            "/usr/share/zoneinfo/America/Adak",
+            "/usr/share/zoneinfo/America/Anchorage",
+            "/usr/share/zoneinfo/America/Anguilla",
+            "/usr/share/zoneinfo/America/Antigua",
+            "/usr/share/zoneinfo/America/Araguaina",
+            "/usr/share/zoneinfo/America/Argentina/Buenos_Aires",
+            "/usr/share/zoneinfo/America/Argentina/Catamarca",
+            "/usr/share/zoneinfo/America/Argentina/Cordoba",
+            "/usr/share/zoneinfo/America/Argentina/Jujuy",
+            "/usr/share/zoneinfo/America/Argentina/La_Rioja",
+            "/usr/share/zoneinfo/America/Argentina/Mendoza",
+            "/usr/share/zoneinfo/America/Argentina/Rio_Gallegos",
+            "/usr/share/zoneinfo/America/Argentina/Salta",
+            "/usr/share/zoneinfo/America/Argentina/San_Juan",
+            "/usr/share/zoneinfo/America/Argentina/San_Luis",
+            "/usr/share/zoneinfo/America/Argentina/Tucuman",
+            "/usr/share/zoneinfo/America/Argentina/Ushuaia",
+            "/usr/share/zoneinfo/America/Aruba",
+            "/usr/share/zoneinfo/America/Asuncion",
+            "/usr/share/zoneinfo/America/Atikokan",
+            "/usr/share/zoneinfo/America/Bahia",
+            "/usr/share/zoneinfo/America/Bahia_Banderas",
+            "/usr/share/zoneinfo/America/Barbados",
+            "/usr/share/zoneinfo/America/Belem",
+            "/usr/share/zoneinfo/America/Belize",
+            "/usr/share/zoneinfo/America/Blanc-Sablon",
+            "/usr/share/zoneinfo/America/Boa_Vista",
+            "/usr/share/zoneinfo/America/Bogota",
+            "/usr/share/zoneinfo/America/Boise",
+            "/usr/share/zoneinfo/America/Cambridge_Bay",
+            "/usr/share/zoneinfo/America/Campo_Grande",
+            "/usr/share/zoneinfo/America/Cancun",
+            "/usr/share/zoneinfo/America/Caracas",
+            "/usr/share/zoneinfo/America/Cayenne",
+            "/usr/share/zoneinfo/America/Cayman",
+            "/usr/share/zoneinfo/America/Chicago",
+            "/usr/share/zoneinfo/America/Chihuahua",
+            "/usr/share/zoneinfo/America/Ciudad_Juarez",
+            "/usr/share/zoneinfo/America/Costa_Rica",
+            "/usr/share/zoneinfo/America/Coyhaique",
+            "/usr/share/zoneinfo/America/Creston",
+            "/usr/share/zoneinfo/America/Cuiaba",
+            "/usr/share/zoneinfo/America/Curacao",
+            "/usr/share/zoneinfo/America/Danmarkshavn",
+            "/usr/share/zoneinfo/America/Dawson",
+            "/usr/share/zoneinfo/America/Dawson_Creek",
+            "/usr/share/zoneinfo/America/Denver",
+            "/usr/share/zoneinfo/America/Detroit",
+            "/usr/share/zoneinfo/America/Dominica",
+            "/usr/share/zoneinfo/America/Edmonton",
+            "/usr/share/zoneinfo/America/Eirunepe",
+            "/usr/share/zoneinfo/America/El_Salvador",
+            "/usr/share/zoneinfo/America/Fort_Nelson",
+            "/usr/share/zoneinfo/America/Fortaleza",
+            "/usr/share/zoneinfo/America/Glace_Bay",
+            "/usr/share/zoneinfo/America/Goose_Bay",
+            "/usr/share/zoneinfo/America/Grand_Turk",
+            "/usr/share/zoneinfo/America/Grenada",
+            "/usr/share/zoneinfo/America/Guadeloupe",
+            "/usr/share/zoneinfo/America/Guatemala",
+            "/usr/share/zoneinfo/America/Guayaquil",
+            "/usr/share/zoneinfo/America/Guyana",
+            "/usr/share/zoneinfo/America/Halifax",
+            "/usr/share/zoneinfo/America/Havana",
+            "/usr/share/zoneinfo/America/Hermosillo",
+            "/usr/share/zoneinfo/America/Indiana/Indianapolis",
+            "/usr/share/zoneinfo/America/Indiana/Knox",
+            "/usr/share/zoneinfo/America/Indiana/Marengo",
+            "/usr/share/zoneinfo/America/Indiana/Petersburg",
+            "/usr/share/zoneinfo/America/Indiana/Tell_City",
+            "/usr/share/zoneinfo/America/Indiana/Vevay",
+            "/usr/share/zoneinfo/America/Indiana/Vincennes",
+            "/usr/share/zoneinfo/America/Indiana/Winamac",
+            "/usr/share/zoneinfo/America/Inuvik",
+            "/usr/share/zoneinfo/America/Iqaluit",
+            "/usr/share/zoneinfo/America/Jamaica",
+            "/usr/share/zoneinfo/America/Juneau",
+            "/usr/share/zoneinfo/America/Kentucky/Louisville",
+            "/usr/share/zoneinfo/America/Kentucky/Monticello",
+            "/usr/share/zoneinfo/America/La_Paz",
+            "/usr/share/zoneinfo/America/Lima",
+            "/usr/share/zoneinfo/America/Los_Angeles",
+            "/usr/share/zoneinfo/America/Maceio",
+            "/usr/share/zoneinfo/America/Managua",
+            "/usr/share/zoneinfo/America/Manaus",
+            "/usr/share/zoneinfo/America/Martinique",
+            "/usr/share/zoneinfo/America/Matamoros",
+            "/usr/share/zoneinfo/America/Mazatlan",
+            "/usr/share/zoneinfo/America/Menominee",
+            "/usr/share/zoneinfo/America/Merida",
+            "/usr/share/zoneinfo/America/Metlakatla",
+            "/usr/share/zoneinfo/America/Mexico_City",
+            "/usr/share/zoneinfo/America/Miquelon",
+            "/usr/share/zoneinfo/America/Moncton",
+            "/usr/share/zoneinfo/America/Monterrey",
+            "/usr/share/zoneinfo/America/Montevideo",
+            "/usr/share/zoneinfo/America/Montserrat",
+            "/usr/share/zoneinfo/America/Nassau",
+            "/usr/share/zoneinfo/America/New_York",
+            "/usr/share/zoneinfo/America/Nome",
+            "/usr/share/zoneinfo/America/Noronha",
+            "/usr/share/zoneinfo/America/North_Dakota/Beulah",
+            "/usr/share/zoneinfo/America/North_Dakota/Center",
+            "/usr/share/zoneinfo/America/North_Dakota/New_Salem",
+            "/usr/share/zoneinfo/America/Nuuk",
+            "/usr/share/zoneinfo/America/Ojinaga",
+            "/usr/share/zoneinfo/America/Panama",
+            "/usr/share/zoneinfo/America/Paramaribo",
+            "/usr/share/zoneinfo/America/Phoenix",
+            "/usr/share/zoneinfo/America/Port-au-Prince",
+            "/usr/share/zoneinfo/America/Port_of_Spain",
+            "/usr/share/zoneinfo/America/Porto_Velho",
+            "/usr/share/zoneinfo/America/Puerto_Rico",
+            "/usr/share/zoneinfo/America/Punta_Arenas",
+            "/usr/share/zoneinfo/America/Rankin_Inlet",
+            "/usr/share/zoneinfo/America/Recife",
+            "/usr/share/zoneinfo/America/Regina",
+            "/usr/share/zoneinfo/America/Resolute",
+            "/usr/share/zoneinfo/America/Rio_Branco",
+            "/usr/share/zoneinfo/America/Santarem",
+            "/usr/share/zoneinfo/America/Santiago",
+            "/usr/share/zoneinfo/America/Santo_Domingo",
+            "/usr/share/zoneinfo/America/Sao_Paulo",
+            "/usr/share/zoneinfo/America/Scoresbysund",
+            "/usr/share/zoneinfo/America/Sitka",
+            "/usr/share/zoneinfo/America/St_Johns",
+            "/usr/share/zoneinfo/America/St_Kitts",
+            "/usr/share/zoneinfo/America/St_Lucia",
+            "/usr/share/zoneinfo/America/St_Thomas",
+            "/usr/share/zoneinfo/America/St_Vincent",
+            "/usr/share/zoneinfo/America/Swift_Current",
+            "/usr/share/zoneinfo/America/Tegucigalpa",
+            "/usr/share/zoneinfo/America/Thule",
+            "/usr/share/zoneinfo/America/Tijuana",
+            "/usr/share/zoneinfo/America/Toronto",
+            "/usr/share/zoneinfo/America/Tortola",
+            "/usr/share/zoneinfo/America/Vancouver",
+            "/usr/share/zoneinfo/America/Whitehorse",
+            "/usr/share/zoneinfo/America/Winnipeg",
+            "/usr/share/zoneinfo/America/Yakutat",
+            "/usr/share/zoneinfo/Antarctica/Casey",
+            "/usr/share/zoneinfo/Antarctica/Davis",
+            "/usr/share/zoneinfo/Antarctica/DumontDUrville",
+            "/usr/share/zoneinfo/Antarctica/Macquarie",
+            "/usr/share/zoneinfo/Antarctica/Mawson",
+            "/usr/share/zoneinfo/Antarctica/McMurdo",
+            "/usr/share/zoneinfo/Antarctica/Palmer",
+            "/usr/share/zoneinfo/Antarctica/Rothera",
+            "/usr/share/zoneinfo/Antarctica/Syowa",
+            "/usr/share/zoneinfo/Antarctica/Troll",
+            "/usr/share/zoneinfo/Antarctica/Vostok",
+            "/usr/share/zoneinfo/Asia/Aden",
+            "/usr/share/zoneinfo/Asia/Almaty",
+            "/usr/share/zoneinfo/Asia/Amman",
+            "/usr/share/zoneinfo/Asia/Anadyr",
+            "/usr/share/zoneinfo/Asia/Aqtau",
+            "/usr/share/zoneinfo/Asia/Aqtobe",
+            "/usr/share/zoneinfo/Asia/Ashgabat",
+            "/usr/share/zoneinfo/Asia/Atyrau",
+            "/usr/share/zoneinfo/Asia/Baghdad",
+            "/usr/share/zoneinfo/Asia/Bahrain",
+            "/usr/share/zoneinfo/Asia/Baku",
+            "/usr/share/zoneinfo/Asia/Bangkok",
+            "/usr/share/zoneinfo/Asia/Barnaul",
+            "/usr/share/zoneinfo/Asia/Beirut",
+            "/usr/share/zoneinfo/Asia/Bishkek",
+            "/usr/share/zoneinfo/Asia/Brunei",
+            "/usr/share/zoneinfo/Asia/Chita",
+            "/usr/share/zoneinfo/Asia/Colombo",
+            "/usr/share/zoneinfo/Asia/Damascus",
+            "/usr/share/zoneinfo/Asia/Dhaka",
+            "/usr/share/zoneinfo/Asia/Dili",
+            "/usr/share/zoneinfo/Asia/Dubai",
+            "/usr/share/zoneinfo/Asia/Dushanbe",
+            "/usr/share/zoneinfo/Asia/Famagusta",
+            "/usr/share/zoneinfo/Asia/Gaza",
+            "/usr/share/zoneinfo/Asia/Hebron",
+            "/usr/share/zoneinfo/Asia/Ho_Chi_Minh",
+            "/usr/share/zoneinfo/Asia/Hong_Kong",
+            "/usr/share/zoneinfo/Asia/Hovd",
+            "/usr/share/zoneinfo/Asia/Irkutsk",
+            "/usr/share/zoneinfo/Asia/Jakarta",
+            "/usr/share/zoneinfo/Asia/Jayapura",
+            "/usr/share/zoneinfo/Asia/Jerusalem",
+            "/usr/share/zoneinfo/Asia/Kabul",
+            "/usr/share/zoneinfo/Asia/Kamchatka",
+            "/usr/share/zoneinfo/Asia/Karachi",
+            "/usr/share/zoneinfo/Asia/Kathmandu",
+            "/usr/share/zoneinfo/Asia/Khandyga",
+            "/usr/share/zoneinfo/Asia/Kolkata",
+            "/usr/share/zoneinfo/Asia/Krasnoyarsk",
+            "/usr/share/zoneinfo/Asia/Kuala_Lumpur",
+            "/usr/share/zoneinfo/Asia/Kuching",
+            "/usr/share/zoneinfo/Asia/Kuwait",
+            "/usr/share/zoneinfo/Asia/Macau",
+            "/usr/share/zoneinfo/Asia/Magadan",
+            "/usr/share/zoneinfo/Asia/Makassar",
+            "/usr/share/zoneinfo/Asia/Manila",
+            "/usr/share/zoneinfo/Asia/Muscat",
+            "/usr/share/zoneinfo/Asia/Nicosia",
+            "/usr/share/zoneinfo/Asia/Novokuznetsk",
+            "/usr/share/zoneinfo/Asia/Novosibirsk",
+            "/usr/share/zoneinfo/Asia/Omsk",
+            "/usr/share/zoneinfo/Asia/Oral",
+            "/usr/share/zoneinfo/Asia/Phnom_Penh",
+            "/usr/share/zoneinfo/Asia/Pontianak",
+            "/usr/share/zoneinfo/Asia/Pyongyang",
+            "/usr/share/zoneinfo/Asia/Qatar",
+            "/usr/share/zoneinfo/Asia/Qostanay",
+            "/usr/share/zoneinfo/Asia/Qyzylorda",
+            "/usr/share/zoneinfo/Asia/Riyadh",
+            "/usr/share/zoneinfo/Asia/Sakhalin",
+            "/usr/share/zoneinfo/Asia/Samarkand",
+            "/usr/share/zoneinfo/Asia/Seoul",
+            "/usr/share/zoneinfo/Asia/Shanghai",
+            "/usr/share/zoneinfo/Asia/Singapore",
+            "/usr/share/zoneinfo/Asia/Srednekolymsk",
+            "/usr/share/zoneinfo/Asia/Taipei",
+            "/usr/share/zoneinfo/Asia/Tashkent",
+            "/usr/share/zoneinfo/Asia/Tbilisi",
+            "/usr/share/zoneinfo/Asia/Tehran",
+            "/usr/share/zoneinfo/Asia/Thimphu",
+            "/usr/share/zoneinfo/Asia/Tokyo",
+            "/usr/share/zoneinfo/Asia/Tomsk",
+            "/usr/share/zoneinfo/Asia/Ulaanbaatar",
+            "/usr/share/zoneinfo/Asia/Urumqi",
+            "/usr/share/zoneinfo/Asia/Ust-Nera",
+            "/usr/share/zoneinfo/Asia/Vientiane",
+            "/usr/share/zoneinfo/Asia/Vladivostok",
+            "/usr/share/zoneinfo/Asia/Yakutsk",
+            "/usr/share/zoneinfo/Asia/Yangon",
+            "/usr/share/zoneinfo/Asia/Yekaterinburg",
+            "/usr/share/zoneinfo/Asia/Yerevan",
+            "/usr/share/zoneinfo/Atlantic/Azores",
+            "/usr/share/zoneinfo/Atlantic/Bermuda",
+            "/usr/share/zoneinfo/Atlantic/Canary",
+            "/usr/share/zoneinfo/Atlantic/Cape_Verde",
+            "/usr/share/zoneinfo/Atlantic/Faroe",
+            "/usr/share/zoneinfo/Atlantic/Madeira",
+            "/usr/share/zoneinfo/Atlantic/Reykjavik",
+            "/usr/share/zoneinfo/Atlantic/South_Georgia",
+            "/usr/share/zoneinfo/Atlantic/St_Helena",
+            "/usr/share/zoneinfo/Atlantic/Stanley",
+            "/usr/share/zoneinfo/Australia/Adelaide",
+            "/usr/share/zoneinfo/Australia/Brisbane",
+            "/usr/share/zoneinfo/Australia/Broken_Hill",
+            "/usr/share/zoneinfo/Australia/Darwin",
+            "/usr/share/zoneinfo/Australia/Eucla",
+            "/usr/share/zoneinfo/Australia/Hobart",
+            "/usr/share/zoneinfo/Australia/Lindeman",
+            "/usr/share/zoneinfo/Australia/Lord_Howe",
+            "/usr/share/zoneinfo/Australia/Melbourne",
+            "/usr/share/zoneinfo/Australia/Perth",
+            "/usr/share/zoneinfo/Australia/Sydney",
+            "/usr/share/zoneinfo/Etc/GMT",
+            "/usr/share/zoneinfo/Etc/GMT+1",
+            "/usr/share/zoneinfo/Etc/GMT+10",
+            "/usr/share/zoneinfo/Etc/GMT+11",
+            "/usr/share/zoneinfo/Etc/GMT+12",
+            "/usr/share/zoneinfo/Etc/GMT+2",
+            "/usr/share/zoneinfo/Etc/GMT+3",
+            "/usr/share/zoneinfo/Etc/GMT+4",
+            "/usr/share/zoneinfo/Etc/GMT+5",
+            "/usr/share/zoneinfo/Etc/GMT+6",
+            "/usr/share/zoneinfo/Etc/GMT+7",
+            "/usr/share/zoneinfo/Etc/GMT+8",
+            "/usr/share/zoneinfo/Etc/GMT+9",
+            "/usr/share/zoneinfo/Etc/GMT-1",
+            "/usr/share/zoneinfo/Etc/GMT-10",
+            "/usr/share/zoneinfo/Etc/GMT-11",
+            "/usr/share/zoneinfo/Etc/GMT-12",
+            "/usr/share/zoneinfo/Etc/GMT-13",
+            "/usr/share/zoneinfo/Etc/GMT-14",
+            "/usr/share/zoneinfo/Etc/GMT-2",
+            "/usr/share/zoneinfo/Etc/GMT-3",
+            "/usr/share/zoneinfo/Etc/GMT-4",
+            "/usr/share/zoneinfo/Etc/GMT-5",
+            "/usr/share/zoneinfo/Etc/GMT-6",
+            "/usr/share/zoneinfo/Etc/GMT-7",
+            "/usr/share/zoneinfo/Etc/GMT-8",
+            "/usr/share/zoneinfo/Etc/GMT-9",
+            "/usr/share/zoneinfo/Etc/UTC",
+            "/usr/share/zoneinfo/Europe/Amsterdam",
+            "/usr/share/zoneinfo/Europe/Andorra",
+            "/usr/share/zoneinfo/Europe/Astrakhan",
+            "/usr/share/zoneinfo/Europe/Athens",
+            "/usr/share/zoneinfo/Europe/Belgrade",
+            "/usr/share/zoneinfo/Europe/Berlin",
+            "/usr/share/zoneinfo/Europe/Brussels",
+            "/usr/share/zoneinfo/Europe/Bucharest",
+            "/usr/share/zoneinfo/Europe/Budapest",
+            "/usr/share/zoneinfo/Europe/Chisinau",
+            "/usr/share/zoneinfo/Europe/Copenhagen",
+            "/usr/share/zoneinfo/Europe/Dublin",
+            "/usr/share/zoneinfo/Europe/Gibraltar",
+            "/usr/share/zoneinfo/Europe/Guernsey",
+            "/usr/share/zoneinfo/Europe/Helsinki",
+            "/usr/share/zoneinfo/Europe/Isle_of_Man",
+            "/usr/share/zoneinfo/Europe/Istanbul",
+            "/usr/share/zoneinfo/Europe/Jersey",
+            "/usr/share/zoneinfo/Europe/Kaliningrad",
+            "/usr/share/zoneinfo/Europe/Kirov",
+            "/usr/share/zoneinfo/Europe/Kyiv",
+            "/usr/share/zoneinfo/Europe/Lisbon",
+            "/usr/share/zoneinfo/Europe/Ljubljana",
+            "/usr/share/zoneinfo/Europe/London",
+            "/usr/share/zoneinfo/Europe/Luxembourg",
+            "/usr/share/zoneinfo/Europe/Madrid",
+            "/usr/share/zoneinfo/Europe/Malta",
+            "/usr/share/zoneinfo/Europe/Minsk",
+            "/usr/share/zoneinfo/Europe/Monaco",
+            "/usr/share/zoneinfo/Europe/Moscow",
+            "/usr/share/zoneinfo/Europe/Oslo",
+            "/usr/share/zoneinfo/Europe/Paris",
+            "/usr/share/zoneinfo/Europe/Prague",
+            "/usr/share/zoneinfo/Europe/Riga",
+            "/usr/share/zoneinfo/Europe/Rome",
+            "/usr/share/zoneinfo/Europe/Samara",
+            "/usr/share/zoneinfo/Europe/Sarajevo",
+            "/usr/share/zoneinfo/Europe/Saratov",
+            "/usr/share/zoneinfo/Europe/Simferopol",
+            "/usr/share/zoneinfo/Europe/Skopje",
+            "/usr/share/zoneinfo/Europe/Sofia",
+            "/usr/share/zoneinfo/Europe/Stockholm",
+            "/usr/share/zoneinfo/Europe/Tallinn",
+            "/usr/share/zoneinfo/Europe/Tirane",
+            "/usr/share/zoneinfo/Europe/Ulyanovsk",
+            "/usr/share/zoneinfo/Europe/Vaduz",
+            "/usr/share/zoneinfo/Europe/Vienna",
+            "/usr/share/zoneinfo/Europe/Vilnius",
+            "/usr/share/zoneinfo/Europe/Volgograd",
+            "/usr/share/zoneinfo/Europe/Warsaw",
+            "/usr/share/zoneinfo/Europe/Zagreb",
+            "/usr/share/zoneinfo/Europe/Zurich",
+            "/usr/share/zoneinfo/Factory",
+            "/usr/share/zoneinfo/Indian/Antananarivo",
+            "/usr/share/zoneinfo/Indian/Chagos",
+            "/usr/share/zoneinfo/Indian/Christmas",
+            "/usr/share/zoneinfo/Indian/Cocos",
+            "/usr/share/zoneinfo/Indian/Comoro",
+            "/usr/share/zoneinfo/Indian/Kerguelen",
+            "/usr/share/zoneinfo/Indian/Mahe",
+            "/usr/share/zoneinfo/Indian/Maldives",
+            "/usr/share/zoneinfo/Indian/Mauritius",
+            "/usr/share/zoneinfo/Indian/Mayotte",
+            "/usr/share/zoneinfo/Indian/Reunion",
+            "/usr/share/zoneinfo/Pacific/Apia",
+            "/usr/share/zoneinfo/Pacific/Auckland",
+            "/usr/share/zoneinfo/Pacific/Bougainville",
+            "/usr/share/zoneinfo/Pacific/Chatham",
+            "/usr/share/zoneinfo/Pacific/Chuuk",
+            "/usr/share/zoneinfo/Pacific/Easter",
+            "/usr/share/zoneinfo/Pacific/Efate",
+            "/usr/share/zoneinfo/Pacific/Fakaofo",
+            "/usr/share/zoneinfo/Pacific/Fiji",
+            "/usr/share/zoneinfo/Pacific/Funafuti",
+            "/usr/share/zoneinfo/Pacific/Galapagos",
+            "/usr/share/zoneinfo/Pacific/Gambier",
+            "/usr/share/zoneinfo/Pacific/Guadalcanal",
+            "/usr/share/zoneinfo/Pacific/Guam",
+            "/usr/share/zoneinfo/Pacific/Honolulu",
+            "/usr/share/zoneinfo/Pacific/Kanton",
+            "/usr/share/zoneinfo/Pacific/Kiritimati",
+            "/usr/share/zoneinfo/Pacific/Kosrae",
+            "/usr/share/zoneinfo/Pacific/Kwajalein",
+            "/usr/share/zoneinfo/Pacific/Majuro",
+            "/usr/share/zoneinfo/Pacific/Marquesas",
+            "/usr/share/zoneinfo/Pacific/Midway",
+            "/usr/share/zoneinfo/Pacific/Nauru",
+            "/usr/share/zoneinfo/Pacific/Niue",
+            "/usr/share/zoneinfo/Pacific/Norfolk",
+            "/usr/share/zoneinfo/Pacific/Noumea",
+            "/usr/share/zoneinfo/Pacific/Pago_Pago",
+            "/usr/share/zoneinfo/Pacific/Palau",
+            "/usr/share/zoneinfo/Pacific/Pitcairn",
+            "/usr/share/zoneinfo/Pacific/Pohnpei",
+            "/usr/share/zoneinfo/Pacific/Port_Moresby",
+            "/usr/share/zoneinfo/Pacific/Rarotonga",
+            "/usr/share/zoneinfo/Pacific/Saipan",
+            "/usr/share/zoneinfo/Pacific/Tahiti",
+            "/usr/share/zoneinfo/Pacific/Tarawa",
+            "/usr/share/zoneinfo/Pacific/Tongatapu",
+            "/usr/share/zoneinfo/Pacific/Wake",
+            "/usr/share/zoneinfo/Pacific/Wallis",
+            "/usr/share/zoneinfo/iso3166.tab",
+            "/usr/share/zoneinfo/leap-seconds.list",
+            "/usr/share/zoneinfo/leapseconds",
+            "/usr/share/zoneinfo/tzdata.zi",
+            "/usr/share/zoneinfo/zone.tab",
+            "/usr/share/zoneinfo/zone1970.tab",
+            "/usr/share/zoneinfo/zonenow.tab"
+          ]
+        },
+        {
+          "ID": "util-linux@2.41-5",
+          "Name": "util-linux",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/util-linux@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "38be4846f19b7fa"
+          },
+          "Version": "2.41",
+          "Release": "5",
+          "Arch": "amd64",
+          "SrcName": "util-linux",
+          "SrcVersion": "2.41",
+          "SrcRelease": "5",
+          "Licenses": [
+            "GPL-2.0-or-later",
+            "GPL-2.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-or-later",
+            "public-domain",
+            "BSD-4-Clause",
+            "MIT",
+            "ISC",
+            "BSD-3-Clause",
+            "BSLA",
+            "LGPL-2.0-or-later",
+            "BSD-2-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "LGPL-2.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only"
+          ],
+          "Maintainer": "Chris Hofstaedtler \u003czeha@debian.org\u003e",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/bin/choom",
+            "/usr/bin/chrt",
+            "/usr/bin/dmesg",
+            "/usr/bin/fallocate",
+            "/usr/bin/findmnt",
+            "/usr/bin/flock",
+            "/usr/bin/getopt",
+            "/usr/bin/hardlink",
+            "/usr/bin/ionice",
+            "/usr/bin/ipcmk",
+            "/usr/bin/ipcrm",
+            "/usr/bin/ipcs",
+            "/usr/bin/lsblk",
+            "/usr/bin/lscpu",
+            "/usr/bin/lsipc",
+            "/usr/bin/lslocks",
+            "/usr/bin/lslogins",
+            "/usr/bin/lsmem",
+            "/usr/bin/lsns",
+            "/usr/bin/mcookie",
+            "/usr/bin/more",
+            "/usr/bin/mountpoint",
+            "/usr/bin/namei",
+            "/usr/bin/nsenter",
+            "/usr/bin/partx",
+            "/usr/bin/prlimit",
+            "/usr/bin/rename.ul",
+            "/usr/bin/rev",
+            "/usr/bin/setarch",
+            "/usr/bin/setpriv",
+            "/usr/bin/setsid",
+            "/usr/bin/setterm",
+            "/usr/bin/su",
+            "/usr/bin/taskset",
+            "/usr/bin/uclampset",
+            "/usr/bin/unshare",
+            "/usr/bin/wdctl",
+            "/usr/bin/whereis",
+            "/usr/lib/mime/packages/util-linux",
+            "/usr/lib/systemd/system/fstrim.service",
+            "/usr/lib/systemd/system/fstrim.timer",
+            "/usr/sbin/agetty",
+            "/usr/sbin/blkdiscard",
+            "/usr/sbin/blkid",
+            "/usr/sbin/blkzone",
+            "/usr/sbin/blockdev",
+            "/usr/sbin/chcpu",
+            "/usr/sbin/chmem",
+            "/usr/sbin/findfs",
+            "/usr/sbin/fsck",
+            "/usr/sbin/fsfreeze",
+            "/usr/sbin/fstrim",
+            "/usr/sbin/isosize",
+            "/usr/sbin/ldattach",
+            "/usr/sbin/mkfs",
+            "/usr/sbin/mkswap",
+            "/usr/sbin/pivot_root",
+            "/usr/sbin/readprofile",
+            "/usr/sbin/rtcwake",
+            "/usr/sbin/runuser",
+            "/usr/sbin/sulogin",
+            "/usr/sbin/swaplabel",
+            "/usr/sbin/switch_root",
+            "/usr/sbin/wipefs",
+            "/usr/sbin/zramctl",
+            "/usr/share/bash-completion/completions/blkdiscard",
+            "/usr/share/bash-completion/completions/blkid",
+            "/usr/share/bash-completion/completions/blkzone",
+            "/usr/share/bash-completion/completions/blockdev",
+            "/usr/share/bash-completion/completions/chcpu",
+            "/usr/share/bash-completion/completions/chmem",
+            "/usr/share/bash-completion/completions/chrt",
+            "/usr/share/bash-completion/completions/dmesg",
+            "/usr/share/bash-completion/completions/fallocate",
+            "/usr/share/bash-completion/completions/findfs",
+            "/usr/share/bash-completion/completions/findmnt",
+            "/usr/share/bash-completion/completions/flock",
+            "/usr/share/bash-completion/completions/fsck",
+            "/usr/share/bash-completion/completions/fsfreeze",
+            "/usr/share/bash-completion/completions/fstrim",
+            "/usr/share/bash-completion/completions/getopt",
+            "/usr/share/bash-completion/completions/hardlink",
+            "/usr/share/bash-completion/completions/ionice",
+            "/usr/share/bash-completion/completions/ipcmk",
+            "/usr/share/bash-completion/completions/ipcrm",
+            "/usr/share/bash-completion/completions/ipcs",
+            "/usr/share/bash-completion/completions/isosize",
+            "/usr/share/bash-completion/completions/ldattach",
+            "/usr/share/bash-completion/completions/lsblk",
+            "/usr/share/bash-completion/completions/lscpu",
+            "/usr/share/bash-completion/completions/lsipc",
+            "/usr/share/bash-completion/completions/lslocks",
+            "/usr/share/bash-completion/completions/lslogins",
+            "/usr/share/bash-completion/completions/lsmem",
+            "/usr/share/bash-completion/completions/lsns",
+            "/usr/share/bash-completion/completions/mcookie",
+            "/usr/share/bash-completion/completions/mkfs",
+            "/usr/share/bash-completion/completions/mkswap",
+            "/usr/share/bash-completion/completions/more",
+            "/usr/share/bash-completion/completions/mountpoint",
+            "/usr/share/bash-completion/completions/namei",
+            "/usr/share/bash-completion/completions/nsenter",
+            "/usr/share/bash-completion/completions/partx",
+            "/usr/share/bash-completion/completions/pivot_root",
+            "/usr/share/bash-completion/completions/prlimit",
+            "/usr/share/bash-completion/completions/readprofile",
+            "/usr/share/bash-completion/completions/rename.ul",
+            "/usr/share/bash-completion/completions/rev",
+            "/usr/share/bash-completion/completions/rtcwake",
+            "/usr/share/bash-completion/completions/setarch",
+            "/usr/share/bash-completion/completions/setpriv",
+            "/usr/share/bash-completion/completions/setsid",
+            "/usr/share/bash-completion/completions/setterm",
+            "/usr/share/bash-completion/completions/su",
+            "/usr/share/bash-completion/completions/swaplabel",
+            "/usr/share/bash-completion/completions/taskset",
+            "/usr/share/bash-completion/completions/uclampset",
+            "/usr/share/bash-completion/completions/unshare",
+            "/usr/share/bash-completion/completions/wdctl",
+            "/usr/share/bash-completion/completions/whereis",
+            "/usr/share/bash-completion/completions/wipefs",
+            "/usr/share/bash-completion/completions/zramctl",
+            "/usr/share/doc/util-linux/00-about-docs.txt",
+            "/usr/share/doc/util-linux/AUTHORS.gz",
+            "/usr/share/doc/util-linux/NEWS.Debian.gz",
+            "/usr/share/doc/util-linux/PAM-configuration.txt",
+            "/usr/share/doc/util-linux/README.Debian",
+            "/usr/share/doc/util-linux/blkid.txt",
+            "/usr/share/doc/util-linux/cal.txt",
+            "/usr/share/doc/util-linux/changelog.Debian.gz",
+            "/usr/share/doc/util-linux/changelog.gz",
+            "/usr/share/doc/util-linux/col.txt",
+            "/usr/share/doc/util-linux/copyright",
+            "/usr/share/doc/util-linux/deprecated.txt",
+            "/usr/share/doc/util-linux/examples/getopt-example.bash",
+            "/usr/share/doc/util-linux/getopt.txt",
+            "/usr/share/doc/util-linux/getopt_changelog.txt",
+            "/usr/share/doc/util-linux/howto-build-sys.txt",
+            "/usr/share/doc/util-linux/howto-compilation.txt",
+            "/usr/share/doc/util-linux/howto-contribute.txt.gz",
+            "/usr/share/doc/util-linux/howto-debug.txt",
+            "/usr/share/doc/util-linux/howto-man-page.txt",
+            "/usr/share/doc/util-linux/howto-pull-request.txt.gz",
+            "/usr/share/doc/util-linux/howto-tests.txt",
+            "/usr/share/doc/util-linux/howto-usage-function.txt.gz",
+            "/usr/share/doc/util-linux/hwclock.txt",
+            "/usr/share/doc/util-linux/modems-with-agetty.txt",
+            "/usr/share/doc/util-linux/mount.txt",
+            "/usr/share/doc/util-linux/parse-date.txt.gz",
+            "/usr/share/doc/util-linux/pg.txt",
+            "/usr/share/doc/util-linux/poeigl.txt.gz",
+            "/usr/share/doc/util-linux/release-schedule.txt",
+            "/usr/share/doc/util-linux/releases/v2.13-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.14-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.15-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.16-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.17-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.18-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.19-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.20-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.21-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.22-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.23-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.24-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.25-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.26-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.27-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.28-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.29-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.30-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.31-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.32-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.33-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.34-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.35-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.36-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.37-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.38-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.39-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.40-ReleaseNotes.gz",
+            "/usr/share/doc/util-linux/releases/v2.41-ReleaseNotes.gz",
+            "/usr/share/lintian/overrides/util-linux",
+            "/usr/share/man/man1/choom.1.gz",
+            "/usr/share/man/man1/chrt.1.gz",
+            "/usr/share/man/man1/dmesg.1.gz",
+            "/usr/share/man/man1/fallocate.1.gz",
+            "/usr/share/man/man1/flock.1.gz",
+            "/usr/share/man/man1/getopt.1.gz",
+            "/usr/share/man/man1/hardlink.1.gz",
+            "/usr/share/man/man1/ionice.1.gz",
+            "/usr/share/man/man1/ipcmk.1.gz",
+            "/usr/share/man/man1/ipcrm.1.gz",
+            "/usr/share/man/man1/ipcs.1.gz",
+            "/usr/share/man/man1/lscpu.1.gz",
+            "/usr/share/man/man1/lsipc.1.gz",
+            "/usr/share/man/man1/lslogins.1.gz",
+            "/usr/share/man/man1/lsmem.1.gz",
+            "/usr/share/man/man1/mcookie.1.gz",
+            "/usr/share/man/man1/more.1.gz",
+            "/usr/share/man/man1/mountpoint.1.gz",
+            "/usr/share/man/man1/namei.1.gz",
+            "/usr/share/man/man1/nsenter.1.gz",
+            "/usr/share/man/man1/prlimit.1.gz",
+            "/usr/share/man/man1/rename.ul.1.gz",
+            "/usr/share/man/man1/rev.1.gz",
+            "/usr/share/man/man1/runuser.1.gz",
+            "/usr/share/man/man1/setpriv.1.gz",
+            "/usr/share/man/man1/setsid.1.gz",
+            "/usr/share/man/man1/setterm.1.gz",
+            "/usr/share/man/man1/su.1.gz",
+            "/usr/share/man/man1/taskset.1.gz",
+            "/usr/share/man/man1/uclampset.1.gz",
+            "/usr/share/man/man1/unshare.1.gz",
+            "/usr/share/man/man1/whereis.1.gz",
+            "/usr/share/man/man5/adjtime_config.5.gz",
+            "/usr/share/man/man5/scols-filter.5.gz",
+            "/usr/share/man/man5/terminal-colors.d.5.gz",
+            "/usr/share/man/man8/agetty.8.gz",
+            "/usr/share/man/man8/blkdiscard.8.gz",
+            "/usr/share/man/man8/blkid.8.gz",
+            "/usr/share/man/man8/blkzone.8.gz",
+            "/usr/share/man/man8/blockdev.8.gz",
+            "/usr/share/man/man8/chcpu.8.gz",
+            "/usr/share/man/man8/chmem.8.gz",
+            "/usr/share/man/man8/findfs.8.gz",
+            "/usr/share/man/man8/findmnt.8.gz",
+            "/usr/share/man/man8/fsck.8.gz",
+            "/usr/share/man/man8/fsfreeze.8.gz",
+            "/usr/share/man/man8/fstrim.8.gz",
+            "/usr/share/man/man8/isosize.8.gz",
+            "/usr/share/man/man8/ldattach.8.gz",
+            "/usr/share/man/man8/lsblk.8.gz",
+            "/usr/share/man/man8/lslocks.8.gz",
+            "/usr/share/man/man8/lsns.8.gz",
+            "/usr/share/man/man8/mkfs.8.gz",
+            "/usr/share/man/man8/mkswap.8.gz",
+            "/usr/share/man/man8/partx.8.gz",
+            "/usr/share/man/man8/pivot_root.8.gz",
+            "/usr/share/man/man8/readprofile.8.gz",
+            "/usr/share/man/man8/rtcwake.8.gz",
+            "/usr/share/man/man8/setarch.8.gz",
+            "/usr/share/man/man8/sulogin.8.gz",
+            "/usr/share/man/man8/swaplabel.8.gz",
+            "/usr/share/man/man8/switch_root.8.gz",
+            "/usr/share/man/man8/wdctl.8.gz",
+            "/usr/share/man/man8/wipefs.8.gz",
+            "/usr/share/man/man8/zramctl.8.gz",
+            "/usr/share/util-linux/logcheck/ignore.d.server/util-linux"
+          ]
+        },
+        {
+          "ID": "zlib1g@1:1.3.dfsg+really1.3.1-1+b1",
+          "Name": "zlib1g",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/zlib1g@1.3.dfsg%2Breally1.3.1-1%2Bb1?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "4c93a4dae945a3a5"
+          },
+          "Version": "1.3.dfsg+really1.3.1",
+          "Release": "1+b1",
+          "Epoch": 1,
+          "Arch": "amd64",
+          "SrcName": "zlib",
+          "SrcVersion": "1.3.dfsg+really1.3.1",
+          "SrcRelease": "1",
+          "SrcEpoch": 1,
+          "Licenses": [
+            "Zlib"
+          ],
+          "Maintainer": "Mark Brown \u003cbroonie@debian.org\u003e",
+          "DependsOn": [
+            "libc6@2.41-12"
+          ],
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "InstalledFiles": [
+            "/usr/lib/x86_64-linux-gnu/libz.so.1.3.1",
+            "/usr/share/doc/zlib1g/changelog.Debian.amd64.gz",
+            "/usr/share/doc/zlib1g/changelog.Debian.gz",
+            "/usr/share/doc/zlib1g/changelog.gz",
+            "/usr/share/doc/zlib1g/copyright"
+          ]
+        }
+      ],
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2011-3374",
+          "PkgID": "apt@3.0.3",
+          "PkgName": "apt",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/apt@3.0.3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "26cbc052ac267c2"
+          },
+          "InstalledVersion": "3.0.3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-3374",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:6af7d2384e46eff32b27ab861ef0a8527aa616d9d1ad0119534479598fbb767c",
+          "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
+          "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-347"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V2Score": 4.3,
+              "V3Score": 3.7
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/cve-2011-3374",
+            "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=642480",
+            "https://people.canonical.com/~ubuntu-security/cve/2011/CVE-2011-3374.html",
+            "https://seclists.org/fulldisclosure/2011/Sep/221",
+            "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+            "https://snyk.io/vuln/SNYK-LINUX-APT-116518",
+            "https://ubuntu.com/security/CVE-2011-3374"
+          ],
+          "PublishedDate": "2019-11-26T00:15:11.03Z",
+          "LastModifiedDate": "2024-11-21T01:30:22.61Z"
+        },
+        {
+          "VulnerabilityID": "TEMP-0841856-B18BAF",
+          "PkgID": "bash@5.2.37-2+b5",
+          "PkgName": "bash",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/bash@5.2.37-2%2Bb5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "235aa9088a703d3c"
+          },
+          "InstalledVersion": "5.2.37-2+b5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0841856-B18BAF",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:6b074b4baece6be097055b25fa880f84f40ceda6290ab88d1198b0ce24399dce",
+          "Title": "[Privilege escalation possible to other user than root]",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1
+          }
+        },
+        {
+          "VulnerabilityID": "CVE-2018-7738",
+          "PkgID": "bash-completion@1:2.16.0-7",
+          "PkgName": "bash-completion",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/bash-completion@2.16.0-7?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "6e03bae277e89d0c"
+          },
+          "InstalledVersion": "1:2.16.0-7",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-7738",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:c115f77f25b23200f228a5913f236574c3f170b7d48d4219dd21743c00f930be",
+          "Title": "util-linux: Shell command injection in unescaped bash-completed mount point names",
+          "Description": "In util-linux before 2.32-rc1, bash-completion/umount allows local users to gain privileges by embedding shell commands in a mountpoint name, which is mishandled during a umount command (within Bash) by a different user, as demonstrated by logging in as root and entering umount followed by a tab character for autocompletion.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "amazon": 2,
+            "debian": 1,
+            "nvd": 3,
+            "photon": 3,
+            "redhat": 2,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "V2Score": 7.2,
+              "V3Score": 7.8
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 6.7
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/103367",
+            "https://access.redhat.com/security/cve/CVE-2018-7738",
+            "https://bugs.debian.org/892179",
+            "https://github.com/karelzak/util-linux/commit/75f03badd7ed9f1dd951863d75e756883d3acc55",
+            "https://github.com/karelzak/util-linux/issues/539",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-7738",
+            "https://security.netapp.com/advisory/ntap-20241213-0002/",
+            "https://ubuntu.com/security/notices/USN-4512-1",
+            "https://usn.ubuntu.com/4512-1/",
+            "https://www.cve.org/CVERecord?id=CVE-2018-7738",
+            "https://www.debian.org/security/2018/dsa-4134"
+          ],
+          "PublishedDate": "2018-03-07T02:29:03.533Z",
+          "LastModifiedDate": "2024-12-13T14:15:19.38Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "bsdutils@1:2.41-5",
+          "PkgName": "bsdutils",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/bsdutils@2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "c9de60be80a96a27"
+          },
+          "InstalledVersion": "1:2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:5eb025baf5a3a7223e211b90a2fa39dd891fca1a27267215ef9d9a0184d49581",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "bsdutils@1:2.41-5",
+          "PkgName": "bsdutils",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/bsdutils@2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "c9de60be80a96a27"
+          },
+          "InstalledVersion": "1:2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b21b5fdb167b21ed97791fdd2b621a15856546bc5d35cb4324a75803cc448d77",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2017-18018",
+          "PkgID": "coreutils@9.7-3",
+          "PkgName": "coreutils",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/coreutils@9.7-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a90cbdbcbab1768e"
+          },
+          "InstalledVersion": "9.7-3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2017-18018",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:48610c5f8f955b6b75baee618fb4f87e42cebc4492d7645ca3117690a998c601",
+          "Title": "coreutils: race condition vulnerability in chown and chgrp",
+          "Description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-362"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 1.9,
+              "V3Score": 4.7
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L",
+              "V3Score": 4.2
+            }
+          },
+          "References": [
+            "http://lists.gnu.org/archive/html/coreutils/2017-12/msg00045.html",
+            "https://access.redhat.com/security/cve/CVE-2017-18018",
+            "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
+            "https://www.cve.org/CVERecord?id=CVE-2017-18018"
+          ],
+          "PublishedDate": "2018-01-04T04:29:00.19Z",
+          "LastModifiedDate": "2025-06-09T16:15:27.25Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-5278",
+          "PkgID": "coreutils@9.7-3",
+          "PkgName": "coreutils",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/coreutils@9.7-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a90cbdbcbab1768e"
+          },
+          "InstalledVersion": "9.7-3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-5278",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b882a31311dd646a54d6c217ac3e44b0b822ccddb0edf716b87feb856dfd8d22",
+          "Title": "coreutils: Heap Buffer Under-Read in GNU Coreutils sort via Key Specification",
+          "Description": "A flaw was found in GNU Coreutils. The sort utility's begfield() function is vulnerable to a heap buffer under-read. The program may access memory outside the allocated buffer if a user runs a crafted command using the traditional key format. A malicious input could lead to a crash or leak sensitive data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-121"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "debian": 1,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:L",
+              "V3Score": 4.4
+            }
+          },
+          "References": [
+            "http://www.openwall.com/lists/oss-security/2025/05/27/2",
+            "http://www.openwall.com/lists/oss-security/2025/05/29/1",
+            "http://www.openwall.com/lists/oss-security/2025/05/29/2",
+            "https://access.redhat.com/security/cve/CVE-2025-5278",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2368764",
+            "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=8c9602e3a145e9596dc1a63c6ed67865814b6633",
+            "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?id=8c9602e3a145e9596dc1a63c6ed67865814b6633#n14",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-5278",
+            "https://security-tracker.debian.org/tracker/CVE-2025-5278",
+            "https://www.cve.org/CVERecord?id=CVE-2025-5278"
+          ],
+          "PublishedDate": "2025-05-27T21:15:23.197Z",
+          "LastModifiedDate": "2025-10-22T20:15:37.32Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-10966",
+          "PkgID": "curl@8.14.1-2+deb13u2",
+          "PkgName": "curl",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/curl@8.14.1-2%2Bdeb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d75e0bb035cd8a38"
+          },
+          "InstalledVersion": "8.14.1-2+deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-10966",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:9580f17463e026f50cb18ee0ea61aa525ff18201d6515671ca6acfbea88d12ab",
+          "Title": "curl: Curl missing SFTP host verification with wolfSSH backend",
+          "Description": "curl's code for managing SSH connections when SFTP was done using the wolfSSH\npowered backend was flawed and missed host verification mechanisms.\n\nThis prevents curl from detecting MITM attackers and more.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1,
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "http://www.openwall.com/lists/oss-security/2025/11/05/2",
+            "https://access.redhat.com/security/cve/CVE-2025-10966",
+            "https://curl.se/docs/CVE-2025-10966.html",
+            "https://curl.se/docs/CVE-2025-10966.json",
+            "https://github.com/curl/curl/commit/b011e3fcfb06d6c027859",
+            "https://hackerone.com/reports/3355218",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-10966",
+            "https://www.cve.org/CVERecord?id=CVE-2025-10966"
+          ],
+          "PublishedDate": "2025-11-07T08:15:39.617Z",
+          "LastModifiedDate": "2025-11-12T16:20:22.257Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-5709",
+          "PkgID": "krb5-locales@1.21.3-5",
+          "PkgName": "krb5-locales",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/krb5-locales@1.21.3-5?arch=all\u0026distro=debian-13.1",
+            "UID": "e9e09fdd7f36416e"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-5709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:95be3a97769ac38fa91f938716bd69e6649535afd7270a6364db2ed1ae72bbe3",
+          "Title": "krb5: integer overflow in dbentry-\u003en_key_data in kadmin/dbutil/dump.c",
+          "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+              "V3Score": 6.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2018-5709",
+            "https://github.com/poojamnit/Kerberos-V5-1.16-Vulnerabilities/tree/master/Integer%20Overflow",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+            "https://www.cve.org/CVERecord?id=CVE-2018-5709"
+          ],
+          "PublishedDate": "2018-01-16T09:29:00.5Z",
+          "LastModifiedDate": "2024-11-21T04:09:13.037Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26458",
+          "PkgID": "krb5-locales@1.21.3-5",
+          "PkgName": "krb5-locales",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/krb5-locales@1.21.3-5?arch=all\u0026distro=debian-13.1",
+            "UID": "e9e09fdd7f36416e"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26458",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:68c10496fe717eabb9924c771e92db9f9c6183922b08ce5ddeffbc7fa6dd9f33",
+          "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26458",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_1.md",
+            "https://linux.oracle.com/cve/CVE-2024-26458.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26458",
+            "https://security.netapp.com/advisory/ntap-20240415-0010/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26458"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.78Z",
+          "LastModifiedDate": "2025-05-23T15:39:31.357Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26461",
+          "PkgID": "krb5-locales@1.21.3-5",
+          "PkgName": "krb5-locales",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/krb5-locales@1.21.3-5?arch=all\u0026distro=debian-13.1",
+            "UID": "e9e09fdd7f36416e"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26461",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:954f9c7c58081fd537ba6ce4a6c2b6ba52c5de589f292fffd4baa26ee3b268f6",
+          "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-770"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 3,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26461",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_2.md",
+            "https://linux.oracle.com/cve/CVE-2024-26461.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26461",
+            "https://security.netapp.com/advisory/ntap-20240415-0011/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26461"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.82Z",
+          "LastModifiedDate": "2025-05-23T15:30:30.847Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2011-3374",
+          "PkgID": "libapt-pkg7.0@3.0.3",
+          "PkgName": "libapt-pkg7.0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libapt-pkg7.0@3.0.3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "80dd2636db3e0564"
+          },
+          "InstalledVersion": "3.0.3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-3374",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:c5006cd3f76cb267a52f35436aeca01b00431290a8ff924530cc25fa9cc09c52",
+          "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
+          "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-347"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V2Score": 4.3,
+              "V3Score": 3.7
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/cve-2011-3374",
+            "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=642480",
+            "https://people.canonical.com/~ubuntu-security/cve/2011/CVE-2011-3374.html",
+            "https://seclists.org/fulldisclosure/2011/Sep/221",
+            "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+            "https://snyk.io/vuln/SNYK-LINUX-APT-116518",
+            "https://ubuntu.com/security/CVE-2011-3374"
+          ],
+          "PublishedDate": "2019-11-26T00:15:11.03Z",
+          "LastModifiedDate": "2024-11-21T01:30:22.61Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "libblkid1@2.41-5",
+          "PkgName": "libblkid1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libblkid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6c9693ac78293e63"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:06d02253a0575a5f7b2c36688f9c3db5fb04aece70e7628459f36a9cca8921e6",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "libblkid1@2.41-5",
+          "PkgName": "libblkid1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libblkid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6c9693ac78293e63"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:14d80b5245a931f9dbbf7f7a7a09be7ca32dab438729befb3ae191fb1a04df48",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2010-4756",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2010-4756",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:1ddf3f32c03d29e4e6e297ae9be363fbd34e52bd7aea319b428f68fa1562fe3f",
+          "Title": "glibc: glob implementation can cause excessive CPU and memory consumption due to crafted glob expressions",
+          "Description": "The glob implementation in the GNU C Library (aka glibc or libc6) allows remote authenticated users to cause a denial of service (CPU and memory consumption) via crafted glob expressions that do not match any pathnames, as demonstrated by glob expressions in STAT commands to an FTP daemon, a different vulnerability than CVE-2010-2632.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-399"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
+              "V2Score": 4
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V2Score": 5
+            }
+          },
+          "References": [
+            "http://cxib.net/stuff/glob-0day.c",
+            "http://securityreason.com/achievement_securityalert/89",
+            "http://securityreason.com/exploitalert/9223",
+            "https://access.redhat.com/security/cve/CVE-2010-4756",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=681681",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2010-4756",
+            "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
+            "https://security.netapp.com/advisory/ntap-20241108-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2010-4756"
+          ],
+          "PublishedDate": "2011-03-02T20:00:01.037Z",
+          "LastModifiedDate": "2025-11-03T22:15:41.51Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-20796",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-20796",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:cb7ecf419fba8382382ac09744d002799c6d639f54dcaffa80b98d9292f25b84",
+          "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
+          "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(\\227|)(\\\\1\\\\1|t1|\\\\\\2537)+' in grep.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-674"
+          ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/107160",
+            "https://access.redhat.com/security/cve/CVE-2018-20796",
+            "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34141",
+            "https://lists.gnu.org/archive/html/bug-gnulib/2019-01/msg00108.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+            "https://security.netapp.com/advisory/ntap-20190315-0002/",
+            "https://support.f5.com/csp/article/K26346590?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://www.cve.org/CVERecord?id=CVE-2018-20796"
+          ],
+          "PublishedDate": "2019-02-26T02:29:00.45Z",
+          "LastModifiedDate": "2024-11-21T04:02:11.827Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010022",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010022",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:254bff8f4a8276c37cb6f032df05d71c1df85af28b61e57aa26d3dbbff1b5d35",
+          "Title": "glibc: stack guard protection bypass",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass stack guard protection. The component is: nptl. The attack vector is: Exploit stack buffer overflow vulnerability and use this bypass vulnerability to bypass stack guard. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 4
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "V2Score": 7.5,
+              "V3Score": 9.8
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-1010022",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22850",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22850#c3",
+            "https://ubuntu.com/security/CVE-2019-1010022",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010022"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.317Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.5Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010023",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010023",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:57bd8fe82b637504592b02b0d936869dcfca7692f5254ff0dd385751afd33302",
+          "Title": "glibc: running ldd on malicious ELF leads to code execution because of wrong size computation",
+          "Description": "GNU Libc current is affected by: Re-mapping current loaded library with malicious ELF file. The impact is: In worst case attacker may evaluate privileges. The component is: libld. The attack vector is: Attacker sends 2 ELF files to victim and asks to run ldd on it. ldd execute code. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V2Score": 6.8,
+              "V3Score": 8.8
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 7.8
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/109167",
+            "https://access.redhat.com/security/cve/CVE-2019-1010023",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22851",
+            "https://support.f5.com/csp/article/K11932200?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010023",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010023"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.397Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.643Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010024",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010024",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:f8acf252e751490c0dd3d053e512defa768d534541360e29a7d39bd8a64ce6ff",
+          "Title": "glibc: ASLR bypass using cache of thread stack and heap",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass ASLR using cache of thread stack and heap. The component is: glibc. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-200"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V2Score": 5,
+              "V3Score": 5.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/109162",
+            "https://access.redhat.com/security/cve/CVE-2019-1010024",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22852",
+            "https://support.f5.com/csp/article/K06046097",
+            "https://support.f5.com/csp/article/K06046097?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010024",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010024"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.473Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.843Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010025",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010025",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:77774d2448cbbb7234dddf18297768e465983f87cd0857cf08382155d4cb2d35",
+          "Title": "glibc: information disclosure of heap addresses of pthread_created thread",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may guess the heap addresses of pthread_created thread. The component is: glibc. NOTE: the vendor's position is \"ASLR bypass itself is not a vulnerability.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-330"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V2Score": 5,
+              "V3Score": 5.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 2.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-1010025",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22853",
+            "https://support.f5.com/csp/article/K06046097",
+            "https://support.f5.com/csp/article/K06046097?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010025",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010025"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.537Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.96Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-9192",
+          "PkgID": "libc-bin@2.41-12",
+          "PkgName": "libc-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc-bin@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a531ca45463d06a2"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-9192",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:a6c6c7fb28df6ff954582e049e2aab22181870c1bb3433af83e028ed69ee9f0f",
+          "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
+          "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(|)(\\\\1\\\\1)*' in grep, a different issue than CVE-2018-20796. NOTE: the software maintainer disputes that this is a vulnerability because the behavior occurs only with a crafted pattern",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-674"
+          ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:L",
+              "V3Score": 2.8
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-9192",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=24269",
+            "https://support.f5.com/csp/article/K26346590?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://www.cve.org/CVERecord?id=CVE-2019-9192"
+          ],
+          "PublishedDate": "2019-02-26T18:29:00.34Z",
+          "LastModifiedDate": "2024-11-21T04:51:10.53Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2010-4756",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2010-4756",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:0c9561769381e48ce42bdccbe9d0046882e3b3cf359cc0e64faa1d969c7502bc",
+          "Title": "glibc: glob implementation can cause excessive CPU and memory consumption due to crafted glob expressions",
+          "Description": "The glob implementation in the GNU C Library (aka glibc or libc6) allows remote authenticated users to cause a denial of service (CPU and memory consumption) via crafted glob expressions that do not match any pathnames, as demonstrated by glob expressions in STAT commands to an FTP daemon, a different vulnerability than CVE-2010-2632.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-399"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
+              "V2Score": 4
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V2Score": 5
+            }
+          },
+          "References": [
+            "http://cxib.net/stuff/glob-0day.c",
+            "http://securityreason.com/achievement_securityalert/89",
+            "http://securityreason.com/exploitalert/9223",
+            "https://access.redhat.com/security/cve/CVE-2010-4756",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=681681",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2010-4756",
+            "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
+            "https://security.netapp.com/advisory/ntap-20241108-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2010-4756"
+          ],
+          "PublishedDate": "2011-03-02T20:00:01.037Z",
+          "LastModifiedDate": "2025-11-03T22:15:41.51Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-20796",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-20796",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:a340d6adfeb2d435201320b1f01f6835bc23a136a9c3de2d7a4cbd3a8d85a76a",
+          "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
+          "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(\\227|)(\\\\1\\\\1|t1|\\\\\\2537)+' in grep.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-674"
+          ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/107160",
+            "https://access.redhat.com/security/cve/CVE-2018-20796",
+            "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34141",
+            "https://lists.gnu.org/archive/html/bug-gnulib/2019-01/msg00108.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+            "https://security.netapp.com/advisory/ntap-20190315-0002/",
+            "https://support.f5.com/csp/article/K26346590?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://www.cve.org/CVERecord?id=CVE-2018-20796"
+          ],
+          "PublishedDate": "2019-02-26T02:29:00.45Z",
+          "LastModifiedDate": "2024-11-21T04:02:11.827Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010022",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010022",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:395a911e080d5d94c8cfb2560782ac3ceeb3c84f01632a89fee13272a3fdb38b",
+          "Title": "glibc: stack guard protection bypass",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass stack guard protection. The component is: nptl. The attack vector is: Exploit stack buffer overflow vulnerability and use this bypass vulnerability to bypass stack guard. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 4
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "V2Score": 7.5,
+              "V3Score": 9.8
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-1010022",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22850",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22850#c3",
+            "https://ubuntu.com/security/CVE-2019-1010022",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010022"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.317Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.5Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010023",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010023",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b7c89a1c0e895ebeccbe7a1b592e562ff418089b6f2c7bf7e47740c180a79fa4",
+          "Title": "glibc: running ldd on malicious ELF leads to code execution because of wrong size computation",
+          "Description": "GNU Libc current is affected by: Re-mapping current loaded library with malicious ELF file. The impact is: In worst case attacker may evaluate privileges. The component is: libld. The attack vector is: Attacker sends 2 ELF files to victim and asks to run ldd on it. ldd execute code. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V2Score": 6.8,
+              "V3Score": 8.8
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 7.8
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/109167",
+            "https://access.redhat.com/security/cve/CVE-2019-1010023",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22851",
+            "https://support.f5.com/csp/article/K11932200?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010023",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010023"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.397Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.643Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010024",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010024",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:2adfcb24be591379b3a4aa0cdd0217eb2cf539c79ae0a614b3f9705ffdf7791e",
+          "Title": "glibc: ASLR bypass using cache of thread stack and heap",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass ASLR using cache of thread stack and heap. The component is: glibc. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-200"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V2Score": 5,
+              "V3Score": 5.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "http://www.securityfocus.com/bid/109162",
+            "https://access.redhat.com/security/cve/CVE-2019-1010024",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22852",
+            "https://support.f5.com/csp/article/K06046097",
+            "https://support.f5.com/csp/article/K06046097?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010024",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010024"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.473Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.843Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-1010025",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-1010025",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:5f70f9786bf9fe3c43aa081cc59526e51fcbdce2dd2cbfca27432e99dc16e72a",
+          "Title": "glibc: information disclosure of heap addresses of pthread_created thread",
+          "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may guess the heap addresses of pthread_created thread. The component is: glibc. NOTE: the vendor's position is \"ASLR bypass itself is not a vulnerability.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-330"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V2Score": 5,
+              "V3Score": 5.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 2.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-1010025",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+            "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=22853",
+            "https://support.f5.com/csp/article/K06046097",
+            "https://support.f5.com/csp/article/K06046097?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://ubuntu.com/security/CVE-2019-1010025",
+            "https://www.cve.org/CVERecord?id=CVE-2019-1010025"
+          ],
+          "PublishedDate": "2019-07-15T04:15:13.537Z",
+          "LastModifiedDate": "2024-11-21T04:17:55.96Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2019-9192",
+          "PkgID": "libc6@2.41-12",
+          "PkgName": "libc6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libc6@2.41-12?arch=amd64\u0026distro=debian-13.1",
+            "UID": "a6d2d0103571346b"
+          },
+          "InstalledVersion": "2.41-12",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-9192",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:2c5c2588dccef77e34bb0fd3044fe4cd93622ce01b81ccda120e7416daa691b0",
+          "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
+          "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(|)(\\\\1\\\\1)*' in grep, a different issue than CVE-2018-20796. NOTE: the software maintainer disputes that this is a vulnerability because the behavior occurs only with a crafted pattern",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-674"
+          ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:L",
+              "V3Score": 2.8
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2019-9192",
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=24269",
+            "https://support.f5.com/csp/article/K26346590?utm_source=f5support\u0026amp%3Butm_medium=RSS",
+            "https://www.cve.org/CVERecord?id=CVE-2019-9192"
+          ],
+          "PublishedDate": "2019-02-26T18:29:00.34Z",
+          "LastModifiedDate": "2024-11-21T04:51:10.53Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-10966",
+          "PkgID": "libcurl4t64@8.14.1-2+deb13u2",
+          "PkgName": "libcurl4t64",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libcurl4t64@8.14.1-2%2Bdeb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "cfaf3021b0fcfb8f"
+          },
+          "InstalledVersion": "8.14.1-2+deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-10966",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:53c739a8043b061ec6f4e6563b363fbae3063fb2195f0784ea24bcc71d75e762",
+          "Title": "curl: Curl missing SFTP host verification with wolfSSH backend",
+          "Description": "curl's code for managing SSH connections when SFTP was done using the wolfSSH\npowered backend was flawed and missed host verification mechanisms.\n\nThis prevents curl from detecting MITM attackers and more.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1,
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "http://www.openwall.com/lists/oss-security/2025/11/05/2",
+            "https://access.redhat.com/security/cve/CVE-2025-10966",
+            "https://curl.se/docs/CVE-2025-10966.html",
+            "https://curl.se/docs/CVE-2025-10966.json",
+            "https://github.com/curl/curl/commit/b011e3fcfb06d6c027859",
+            "https://hackerone.com/reports/3355218",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-10966",
+            "https://www.cve.org/CVERecord?id=CVE-2025-10966"
+          ],
+          "PublishedDate": "2025-11-07T08:15:39.617Z",
+          "LastModifiedDate": "2025-11-12T16:20:22.257Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2011-3389",
+          "PkgID": "libgnutls30t64@3.8.9-3",
+          "PkgName": "libgnutls30t64",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libgnutls30t64@3.8.9-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ff33dbe4723118d9"
+          },
+          "InstalledVersion": "3.8.9-3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-3389",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:7182a1718f639d82f6ec8bd734c5782cb17d8a2c9e180248eed2bf86b801544a",
+          "Title": "HTTPS: block-wise chosen-plaintext attack against SSL/TLS (BEAST)",
+          "Description": "The SSL protocol, as used in certain configurations in Microsoft Windows and Microsoft Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other products, encrypts data by using CBC mode with chained initialization vectors, which allows man-in-the-middle attackers to obtain plaintext HTTP headers via a blockwise chosen-boundary attack (BCBA) on an HTTPS session, in conjunction with JavaScript code that uses (1) the HTML5 WebSocket API, (2) the Java URLConnection API, or (3) the Silverlight WebClient API, aka a \"BEAST\" attack.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-326"
+          ],
+          "VendorSeverity": {
+            "amazon": 4,
+            "debian": 1,
+            "nvd": 2,
+            "oracle-oval": 4,
+            "redhat": 2,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+              "V2Score": 4.3
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+              "V2Score": 4.3
+            }
+          },
+          "References": [
+            "http://arcticdog.wordpress.com/2012/08/29/beast-openssl-and-apache/",
+            "http://blog.mozilla.com/security/2011/09/27/attack-against-tls-protected-communications/",
+            "http://blogs.technet.com/b/msrc/archive/2011/09/26/microsoft-releases-security-advisory-2588513.aspx",
+            "http://blogs.technet.com/b/srd/archive/2011/09/26/is-ssl-broken-more-about-security-advisory-2588513.aspx",
+            "http://curl.haxx.se/docs/adv_20120124B.html",
+            "http://downloads.asterisk.org/pub/security/AST-2016-001.html",
+            "http://ekoparty.org/2011/juliano-rizzo.php",
+            "http://eprint.iacr.org/2004/111",
+            "http://eprint.iacr.org/2006/136",
+            "http://googlechromereleases.blogspot.com/2011/10/chrome-stable-release.html",
+            "http://isc.sans.edu/diary/SSL+TLS+part+3+/11635",
+            "http://lists.apple.com/archives/Security-announce/2011//Oct/msg00001.html",
+            "http://lists.apple.com/archives/Security-announce/2011//Oct/msg00002.html",
+            "http://lists.apple.com/archives/security-announce/2012/Feb/msg00000.html",
+            "http://lists.apple.com/archives/security-announce/2012/Jul/msg00001.html",
+            "http://lists.apple.com/archives/security-announce/2012/May/msg00001.html",
+            "http://lists.apple.com/archives/security-announce/2012/Sep/msg00004.html",
+            "http://lists.apple.com/archives/security-announce/2013/Oct/msg00004.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2012-01/msg00049.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2012-01/msg00051.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2012-05/msg00009.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2020-01/msg00040.html",
+            "http://marc.info/?l=bugtraq\u0026m=132750579901589\u0026w=2",
+            "http://marc.info/?l=bugtraq\u0026m=132872385320240\u0026w=2",
+            "http://marc.info/?l=bugtraq\u0026m=133365109612558\u0026w=2",
+            "http://marc.info/?l=bugtraq\u0026m=133728004526190\u0026w=2",
+            "http://marc.info/?l=bugtraq\u0026m=134254866602253\u0026w=2",
+            "http://marc.info/?l=bugtraq\u0026m=134254957702612\u0026w=2",
+            "http://my.opera.com/securitygroup/blog/2011/09/28/the-beast-ssl-tls-issue",
+            "http://osvdb.org/74829",
+            "http://rhn.redhat.com/errata/RHSA-2012-0508.html",
+            "http://rhn.redhat.com/errata/RHSA-2013-1455.html",
+            "http://secunia.com/advisories/45791",
+            "http://secunia.com/advisories/47998",
+            "http://secunia.com/advisories/48256",
+            "http://secunia.com/advisories/48692",
+            "http://secunia.com/advisories/48915",
+            "http://secunia.com/advisories/48948",
+            "http://secunia.com/advisories/49198",
+            "http://secunia.com/advisories/55322",
+            "http://secunia.com/advisories/55350",
+            "http://secunia.com/advisories/55351",
+            "http://security.gentoo.org/glsa/glsa-201203-02.xml",
+            "http://security.gentoo.org/glsa/glsa-201406-32.xml",
+            "http://support.apple.com/kb/HT4999",
+            "http://support.apple.com/kb/HT5001",
+            "http://support.apple.com/kb/HT5130",
+            "http://support.apple.com/kb/HT5281",
+            "http://support.apple.com/kb/HT5501",
+            "http://support.apple.com/kb/HT6150",
+            "http://technet.microsoft.com/security/advisory/2588513",
+            "http://vnhacker.blogspot.com/2011/09/beast.html",
+            "http://www.apcmedia.com/salestools/SJHN-7RKGNM/SJHN-7RKGNM_R4_EN.pdf",
+            "http://www.debian.org/security/2012/dsa-2398",
+            "http://www.educatedguesswork.org/2011/09/security_impact_of_the_rizzodu.html",
+            "http://www.ibm.com/developerworks/java/jdk/alerts/",
+            "http://www.imperialviolet.org/2011/09/23/chromeandbeast.html",
+            "http://www.insecure.cl/Beast-SSL.rar",
+            "http://www.kb.cert.org/vuls/id/864643",
+            "http://www.mandriva.com/security/advisories?name=MDVSA-2012:058",
+            "http://www.opera.com/docs/changelogs/mac/1151/",
+            "http://www.opera.com/docs/changelogs/mac/1160/",
+            "http://www.opera.com/docs/changelogs/unix/1151/",
+            "http://www.opera.com/docs/changelogs/unix/1160/",
+            "http://www.opera.com/docs/changelogs/windows/1151/",
+            "http://www.opera.com/docs/changelogs/windows/1160/",
+            "http://www.opera.com/support/kb/view/1004/",
+            "http://www.oracle.com/technetwork/topics/security/cpujan2015-1972971.html",
+            "http://www.oracle.com/technetwork/topics/security/cpujul2015-2367936.html",
+            "http://www.oracle.com/technetwork/topics/security/javacpuoct2011-443431.html",
+            "http://www.redhat.com/support/errata/RHSA-2011-1384.html",
+            "http://www.redhat.com/support/errata/RHSA-2012-0006.html",
+            "http://www.securityfocus.com/bid/49388",
+            "http://www.securityfocus.com/bid/49778",
+            "http://www.securitytracker.com/id/1029190",
+            "http://www.securitytracker.com/id?1025997",
+            "http://www.securitytracker.com/id?1026103",
+            "http://www.securitytracker.com/id?1026704",
+            "http://www.ubuntu.com/usn/USN-1263-1",
+            "http://www.us-cert.gov/cas/techalerts/TA12-010A.html",
+            "https://access.redhat.com/security/cve/CVE-2011-3389",
+            "https://blogs.oracle.com/sunsecurity/entry/multiple_vulnerabilities_in_fetchmail",
+            "https://bugzilla.novell.com/show_bug.cgi?id=719047",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=737506",
+            "https://cert-portal.siemens.com/productcert/pdf/ssa-556833.pdf",
+            "https://docs.microsoft.com/en-us/security-updates/securitybulletins/2012/ms12-006",
+            "https://h20564.www2.hp.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c03839862",
+            "https://hermes.opensuse.org/messages/13154861",
+            "https://hermes.opensuse.org/messages/13155432",
+            "https://ics-cert.us-cert.gov/advisories/ICSMA-18-058-02",
+            "https://linux.oracle.com/cve/CVE-2011-3389.html",
+            "https://linux.oracle.com/errata/ELSA-2011-1380.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2011-3389",
+            "https://oval.cisecurity.org/repository/search/definition/oval%3Aorg.mitre.oval%3Adef%3A14752",
+            "https://ubuntu.com/security/notices/USN-1263-1",
+            "https://www.cve.org/CVERecord?id=CVE-2011-3389"
+          ],
+          "PublishedDate": "2011-09-06T19:55:03.197Z",
+          "LastModifiedDate": "2025-04-11T00:51:21.963Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-9820",
+          "PkgID": "libgnutls30t64@3.8.9-3",
+          "PkgName": "libgnutls30t64",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libgnutls30t64@3.8.9-3?arch=amd64\u0026distro=debian-13.1",
+            "UID": "ff33dbe4723118d9"
+          },
+          "InstalledVersion": "3.8.9-3",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-9820",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:337215e3a5e1ce87dcfd5955d74257b75d10c63c61aec8aa9bc9952335125ba6",
+          "Title": "[GNUTLS-SA-2025-11-18]",
+          "Severity": "UNKNOWN"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-5709",
+          "PkgID": "libgssapi-krb5-2@1.21.3-5",
+          "PkgName": "libgssapi-krb5-2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libgssapi-krb5-2@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e981ef95af866663"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-5709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:57d25c602805fdd29ac7ddda818c7f906307db13200e73eef6fee2955a656ebd",
+          "Title": "krb5: integer overflow in dbentry-\u003en_key_data in kadmin/dbutil/dump.c",
+          "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+              "V3Score": 6.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2018-5709",
+            "https://github.com/poojamnit/Kerberos-V5-1.16-Vulnerabilities/tree/master/Integer%20Overflow",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+            "https://www.cve.org/CVERecord?id=CVE-2018-5709"
+          ],
+          "PublishedDate": "2018-01-16T09:29:00.5Z",
+          "LastModifiedDate": "2024-11-21T04:09:13.037Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26458",
+          "PkgID": "libgssapi-krb5-2@1.21.3-5",
+          "PkgName": "libgssapi-krb5-2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libgssapi-krb5-2@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e981ef95af866663"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26458",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:8aa81de491675cc936a5cb1f4d7ecaf92679e2baa568c06f80f4f1521ca15f39",
+          "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26458",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_1.md",
+            "https://linux.oracle.com/cve/CVE-2024-26458.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26458",
+            "https://security.netapp.com/advisory/ntap-20240415-0010/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26458"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.78Z",
+          "LastModifiedDate": "2025-05-23T15:39:31.357Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26461",
+          "PkgID": "libgssapi-krb5-2@1.21.3-5",
+          "PkgName": "libgssapi-krb5-2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libgssapi-krb5-2@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e981ef95af866663"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26461",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b31d26f9f230152e5b0e7f387cdf3a6947b18a06571b5ba7b5c883870a5a5fd2",
+          "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-770"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 3,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26461",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_2.md",
+            "https://linux.oracle.com/cve/CVE-2024-26461.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26461",
+            "https://security.netapp.com/advisory/ntap-20240415-0011/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26461"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.82Z",
+          "LastModifiedDate": "2025-05-23T15:30:30.847Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-5709",
+          "PkgID": "libk5crypto3@1.21.3-5",
+          "PkgName": "libk5crypto3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libk5crypto3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "654244e38d239af9"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-5709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:16b451e535748de6e77b1199f319ada324b47c7068b1ab4a7df12bfcc7e4b7c3",
+          "Title": "krb5: integer overflow in dbentry-\u003en_key_data in kadmin/dbutil/dump.c",
+          "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+              "V3Score": 6.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2018-5709",
+            "https://github.com/poojamnit/Kerberos-V5-1.16-Vulnerabilities/tree/master/Integer%20Overflow",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+            "https://www.cve.org/CVERecord?id=CVE-2018-5709"
+          ],
+          "PublishedDate": "2018-01-16T09:29:00.5Z",
+          "LastModifiedDate": "2024-11-21T04:09:13.037Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26458",
+          "PkgID": "libk5crypto3@1.21.3-5",
+          "PkgName": "libk5crypto3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libk5crypto3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "654244e38d239af9"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26458",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:8b245412591b3eaccb93fa9b7f988dc578ba57428494e4aa9897ca8cadfb630c",
+          "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26458",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_1.md",
+            "https://linux.oracle.com/cve/CVE-2024-26458.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26458",
+            "https://security.netapp.com/advisory/ntap-20240415-0010/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26458"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.78Z",
+          "LastModifiedDate": "2025-05-23T15:39:31.357Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26461",
+          "PkgID": "libk5crypto3@1.21.3-5",
+          "PkgName": "libk5crypto3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libk5crypto3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "654244e38d239af9"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26461",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:283e01d60dbad3f8ba050f544b16f9c112359e785e1ac97d8b50879e5d63e6ca",
+          "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-770"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 3,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26461",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_2.md",
+            "https://linux.oracle.com/cve/CVE-2024-26461.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26461",
+            "https://security.netapp.com/advisory/ntap-20240415-0011/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26461"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.82Z",
+          "LastModifiedDate": "2025-05-23T15:30:30.847Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-5709",
+          "PkgID": "libkrb5-3@1.21.3-5",
+          "PkgName": "libkrb5-3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5-3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42eb2a7522db520b"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-5709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:48b721cdaf27c5e7ef31d39a7f5134b6c10650720e1cf3cbb1e39b2c57d1487c",
+          "Title": "krb5: integer overflow in dbentry-\u003en_key_data in kadmin/dbutil/dump.c",
+          "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+              "V3Score": 6.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2018-5709",
+            "https://github.com/poojamnit/Kerberos-V5-1.16-Vulnerabilities/tree/master/Integer%20Overflow",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+            "https://www.cve.org/CVERecord?id=CVE-2018-5709"
+          ],
+          "PublishedDate": "2018-01-16T09:29:00.5Z",
+          "LastModifiedDate": "2024-11-21T04:09:13.037Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26458",
+          "PkgID": "libkrb5-3@1.21.3-5",
+          "PkgName": "libkrb5-3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5-3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42eb2a7522db520b"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26458",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:8290d388db8d1a1ecce257dcb6a7bf51cab6b0c74c148eedf7b284411c97d4b3",
+          "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26458",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_1.md",
+            "https://linux.oracle.com/cve/CVE-2024-26458.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26458",
+            "https://security.netapp.com/advisory/ntap-20240415-0010/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26458"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.78Z",
+          "LastModifiedDate": "2025-05-23T15:39:31.357Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26461",
+          "PkgID": "libkrb5-3@1.21.3-5",
+          "PkgName": "libkrb5-3",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5-3@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "42eb2a7522db520b"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26461",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:d320d2888eb97fcbd46aca0e45a94eaac2c70e7349e672e63f939df55ac5bfa1",
+          "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-770"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 3,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26461",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_2.md",
+            "https://linux.oracle.com/cve/CVE-2024-26461.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26461",
+            "https://security.netapp.com/advisory/ntap-20240415-0011/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26461"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.82Z",
+          "LastModifiedDate": "2025-05-23T15:30:30.847Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2018-5709",
+          "PkgID": "libkrb5support0@1.21.3-5",
+          "PkgName": "libkrb5support0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5support0@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7b7b2ceb7abdb0a3"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-5709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:eee0ce8125bb0b7248b0b98ac50e1738fd81023aefa075571dbc5ec914007342",
+          "Title": "krb5: integer overflow in dbentry-\u003en_key_data in kadmin/dbutil/dump.c",
+          "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+              "V3Score": 6.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2018-5709",
+            "https://github.com/poojamnit/Kerberos-V5-1.16-Vulnerabilities/tree/master/Integer%20Overflow",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+            "https://www.cve.org/CVERecord?id=CVE-2018-5709"
+          ],
+          "PublishedDate": "2018-01-16T09:29:00.5Z",
+          "LastModifiedDate": "2024-11-21T04:09:13.037Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26458",
+          "PkgID": "libkrb5support0@1.21.3-5",
+          "PkgName": "libkrb5support0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5support0@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7b7b2ceb7abdb0a3"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26458",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:0d8654982411cac5637cd8db0b8a66227f500d9e26378d0671b0b6bb45501c1c",
+          "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26458",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_1.md",
+            "https://linux.oracle.com/cve/CVE-2024-26458.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26458",
+            "https://security.netapp.com/advisory/ntap-20240415-0010/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26458"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.78Z",
+          "LastModifiedDate": "2025-05-23T15:39:31.357Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-26461",
+          "PkgID": "libkrb5support0@1.21.3-5",
+          "PkgName": "libkrb5support0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libkrb5support0@1.21.3-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "7b7b2ceb7abdb0a3"
+          },
+          "InstalledVersion": "1.21.3-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-26461",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:368ee941b88488ecce3114b4d253628f4e752030109fbab7e8ddaed4a23a6e52",
+          "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
+          "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-770"
+          ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "azure": 3,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2024:9331",
+            "https://access.redhat.com/security/cve/CVE-2024-26461",
+            "https://bugzilla.redhat.com/2266731",
+            "https://bugzilla.redhat.com/2266740",
+            "https://bugzilla.redhat.com/2266742",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266731",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2266740",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26458",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26461",
+            "https://errata.almalinux.org/9/ALSA-2024-9331.html",
+            "https://errata.rockylinux.org/RLSA-2024:3268",
+            "https://github.com/LuMingYinDetect/krb5_defects/blob/main/krb5_detect_2.md",
+            "https://linux.oracle.com/cve/CVE-2024-26461.html",
+            "https://linux.oracle.com/errata/ELSA-2024-9331.html",
+            "https://mailman.mit.edu/pipermail/kerberos/2024-March/023095.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-26461",
+            "https://security.netapp.com/advisory/ntap-20240415-0011/",
+            "https://ubuntu.com/security/notices/USN-7314-1",
+            "https://www.cve.org/CVERecord?id=CVE-2024-26461"
+          ],
+          "PublishedDate": "2024-02-29T01:44:18.82Z",
+          "LastModifiedDate": "2025-05-23T15:30:30.847Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "liblastlog2-2@2.41-5",
+          "PkgName": "liblastlog2-2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/liblastlog2-2@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "df76396cbfd04981"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:458d786f32bcc265bb095bcbfe839c7338eafedd73e5a68570de5d0c38ab4efb",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "liblastlog2-2@2.41-5",
+          "PkgName": "liblastlog2-2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/liblastlog2-2@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "df76396cbfd04981"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:6c8f0a89338b15a33c57dfc4bae869e3fd49b76d9a23bd116dc8a96a774f8e52",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2015-3276",
+          "PkgID": "libldap-common@2.6.10+dfsg-1",
+          "PkgName": "libldap-common",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap-common@2.6.10%2Bdfsg-1?arch=all\u0026distro=debian-13.1",
+            "UID": "1e651153267a4241"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2015-3276",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:9b0e7f81591cb051ca582fee4244b72fd0ac057beee60708fc9130cdae7e09f8",
+          "Title": "openldap: incorrect multi-keyword mode cipherstring parsing",
+          "Description": "The nss_parse_ciphers function in libraries/libldap/tls_m.c in OpenLDAP does not properly parse OpenSSL-style multi-keyword mode cipher strings, which might cause a weaker than intended cipher to be used and allow remote attackers to have unspecified impact via unknown vectors.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+              "V2Score": 4.3
+            }
+          },
+          "References": [
+            "http://rhn.redhat.com/errata/RHSA-2015-2131.html",
+            "http://www.oracle.com/technetwork/topics/security/linuxbulletinoct2015-2719645.html",
+            "http://www.securitytracker.com/id/1034221",
+            "https://access.redhat.com/security/cve/CVE-2015-3276",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=1238322",
+            "https://linux.oracle.com/cve/CVE-2015-3276.html",
+            "https://linux.oracle.com/errata/ELSA-2015-2131.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+            "https://www.cve.org/CVERecord?id=CVE-2015-3276"
+          ],
+          "PublishedDate": "2015-12-07T20:59:03.023Z",
+          "LastModifiedDate": "2025-04-12T10:46:40.837Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2017-14159",
+          "PkgID": "libldap-common@2.6.10+dfsg-1",
+          "PkgName": "libldap-common",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap-common@2.6.10%2Bdfsg-1?arch=all\u0026distro=debian-13.1",
+            "UID": "1e651153267a4241"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2017-14159",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:df9839c6277aa1f599551d1c22f2f8352107446c5099676d864b9790beb31ef8",
+          "Title": "openldap: Privilege escalation via PID file manipulation",
+          "Description": "slapd in OpenLDAP 2.4.45 and earlier creates a PID file after dropping privileges to a non-root account, which might allow local users to kill arbitrary processes by leveraging access to this non-root account for PID file modification before a root script executes a \"kill `cat /pathname`\" command, as demonstrated by openldap-initscript.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-665"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 1.9,
+              "V3Score": 4.7
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "V3Score": 4.4
+            }
+          },
+          "References": [
+            "http://www.openldap.org/its/index.cgi?findid=8703",
+            "https://access.redhat.com/security/cve/CVE-2017-14159",
+            "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
+            "https://www.cve.org/CVERecord?id=CVE-2017-14159",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2017-09-05T18:29:00.133Z",
+          "LastModifiedDate": "2025-04-20T01:37:25.86Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2017-17740",
+          "PkgID": "libldap-common@2.6.10+dfsg-1",
+          "PkgName": "libldap-common",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap-common@2.6.10%2Bdfsg-1?arch=all\u0026distro=debian-13.1",
+            "UID": "1e651153267a4241"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2017-17740",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:36ed385e82832b7c94ea04a60681fe6bb4f2a3094653481af7d2231a0f6490ea",
+          "Title": "openldap: contrib/slapd-modules/nops/nops.c attempts to free stack buffer allowing remote attackers to cause a denial of service",
+          "Description": "contrib/slapd-modules/nops/nops.c in OpenLDAP through 2.4.45, when both the nops module and the memberof overlay are enabled, attempts to free a buffer that was allocated on the stack, which allows remote attackers to cause a denial of service (slapd crash) via a member MODDN operation.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00053.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00058.html",
+            "http://www.openldap.org/its/index.cgi/Incoming?id=8759",
+            "https://access.redhat.com/security/cve/CVE-2017-17740",
+            "https://kc.mcafee.com/corporate/index?page=content\u0026id=SB10365",
+            "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
+            "https://www.cve.org/CVERecord?id=CVE-2017-17740",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2017-12-18T06:29:00.397Z",
+          "LastModifiedDate": "2025-04-20T01:37:25.86Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2020-15719",
+          "PkgID": "libldap-common@2.6.10+dfsg-1",
+          "PkgName": "libldap-common",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap-common@2.6.10%2Bdfsg-1?arch=all\u0026distro=debian-13.1",
+            "UID": "1e651153267a4241"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-15719",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:23b4c908e0716b9da20bd64f007ec3526e5245da04494417604dd19572363a39",
+          "Title": "openldap: Certificate validation incorrectly matches name against CN-ID",
+          "Description": "libldap in certain third-party OpenLDAP packages has a certificate-validation flaw when the third-party package is asserting RFC6125 support. It considers CN even when there is a non-matching subjectAltName (SAN). This is fixed in, for example, openldap-2.4.46-10.el8 in Red Hat Enterprise Linux.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-295"
+          ],
+          "VendorSeverity": {
+            "bitnami": 2,
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "bitnami": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V3Score": 4.2
+            },
+            "nvd": {
+              "V2Vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V2Score": 4,
+              "V3Score": 4.2
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V3Score": 4.2
+            }
+          },
+          "References": [
+            "http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00033.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00059.html",
+            "https://access.redhat.com/errata/RHBA-2019:3674",
+            "https://access.redhat.com/security/cve/CVE-2020-15719",
+            "https://bugs.openldap.org/show_bug.cgi?id=9266",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=1740070",
+            "https://kc.mcafee.com/corporate/index?page=content\u0026id=SB10365",
+            "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
+            "https://www.cve.org/CVERecord?id=CVE-2020-15719",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2020-07-14T14:15:17.667Z",
+          "LastModifiedDate": "2024-11-21T05:06:05.903Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2015-3276",
+          "PkgID": "libldap2@2.6.10+dfsg-1",
+          "PkgName": "libldap2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "57ebb4268feab87d"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2015-3276",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:d90692146c26d03d6678ae17c8252d726fdf0031009d43228ea765cd15ff42f2",
+          "Title": "openldap: incorrect multi-keyword mode cipherstring parsing",
+          "Description": "The nss_parse_ciphers function in libraries/libldap/tls_m.c in OpenLDAP does not properly parse OpenSSL-style multi-keyword mode cipher strings, which might cause a weaker than intended cipher to be used and allow remote attackers to have unspecified impact via unknown vectors.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+              "V2Score": 4.3
+            }
+          },
+          "References": [
+            "http://rhn.redhat.com/errata/RHSA-2015-2131.html",
+            "http://www.oracle.com/technetwork/topics/security/linuxbulletinoct2015-2719645.html",
+            "http://www.securitytracker.com/id/1034221",
+            "https://access.redhat.com/security/cve/CVE-2015-3276",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=1238322",
+            "https://linux.oracle.com/cve/CVE-2015-3276.html",
+            "https://linux.oracle.com/errata/ELSA-2015-2131.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+            "https://www.cve.org/CVERecord?id=CVE-2015-3276"
+          ],
+          "PublishedDate": "2015-12-07T20:59:03.023Z",
+          "LastModifiedDate": "2025-04-12T10:46:40.837Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2017-14159",
+          "PkgID": "libldap2@2.6.10+dfsg-1",
+          "PkgName": "libldap2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "57ebb4268feab87d"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2017-14159",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:ba59a897033524fbd042b28922d18adb9fafaef1686bcaa72028779d4ac0fa52",
+          "Title": "openldap: Privilege escalation via PID file manipulation",
+          "Description": "slapd in OpenLDAP 2.4.45 and earlier creates a PID file after dropping privileges to a non-root account, which might allow local users to kill arbitrary processes by leveraging access to this non-root account for PID file modification before a root script executes a \"kill `cat /pathname`\" command, as demonstrated by openldap-initscript.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-665"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 1.9,
+              "V3Score": 4.7
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "V3Score": 4.4
+            }
+          },
+          "References": [
+            "http://www.openldap.org/its/index.cgi?findid=8703",
+            "https://access.redhat.com/security/cve/CVE-2017-14159",
+            "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
+            "https://www.cve.org/CVERecord?id=CVE-2017-14159",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2017-09-05T18:29:00.133Z",
+          "LastModifiedDate": "2025-04-20T01:37:25.86Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2017-17740",
+          "PkgID": "libldap2@2.6.10+dfsg-1",
+          "PkgName": "libldap2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "57ebb4268feab87d"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2017-17740",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:f32dc9ced5bf6422d749cc4a7d6de8da41ff271d333914155fb95258c35b199f",
+          "Title": "openldap: contrib/slapd-modules/nops/nops.c attempts to free stack buffer allowing remote attackers to cause a denial of service",
+          "Description": "contrib/slapd-modules/nops/nops.c in OpenLDAP through 2.4.45, when both the nops module and the memberof overlay are enabled, attempts to free a buffer that was allocated on the stack, which allows remote attackers to cause a denial of service (slapd crash) via a member MODDN operation.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 5.9
+            }
+          },
+          "References": [
+            "http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00053.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00058.html",
+            "http://www.openldap.org/its/index.cgi/Incoming?id=8759",
+            "https://access.redhat.com/security/cve/CVE-2017-17740",
+            "https://kc.mcafee.com/corporate/index?page=content\u0026id=SB10365",
+            "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
+            "https://www.cve.org/CVERecord?id=CVE-2017-17740",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2017-12-18T06:29:00.397Z",
+          "LastModifiedDate": "2025-04-20T01:37:25.86Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2020-15719",
+          "PkgID": "libldap2@2.6.10+dfsg-1",
+          "PkgName": "libldap2",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "57ebb4268feab87d"
+          },
+          "InstalledVersion": "2.6.10+dfsg-1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:f4ed40b4dfb25429925705fe079155fec655d57a60c8372d836a840322446eb7"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-15719",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:7e3ca45aa7f686195cfa5e0e0f858980523ca90fa9f918b7059ae2998d523bf5",
+          "Title": "openldap: Certificate validation incorrectly matches name against CN-ID",
+          "Description": "libldap in certain third-party OpenLDAP packages has a certificate-validation flaw when the third-party package is asserting RFC6125 support. It considers CN even when there is a non-matching subjectAltName (SAN). This is fixed in, for example, openldap-2.4.46-10.el8 in Red Hat Enterprise Linux.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-295"
+          ],
+          "VendorSeverity": {
+            "bitnami": 2,
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "bitnami": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V3Score": 4.2
+            },
+            "nvd": {
+              "V2Vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V2Score": 4,
+              "V3Score": 4.2
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "V3Score": 4.2
+            }
+          },
+          "References": [
+            "http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00033.html",
+            "http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00059.html",
+            "https://access.redhat.com/errata/RHBA-2019:3674",
+            "https://access.redhat.com/security/cve/CVE-2020-15719",
+            "https://bugs.openldap.org/show_bug.cgi?id=9266",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=1740070",
+            "https://kc.mcafee.com/corporate/index?page=content\u0026id=SB10365",
+            "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
+            "https://www.cve.org/CVERecord?id=CVE-2020-15719",
+            "https://www.oracle.com/security-alerts/cpuapr2022.html"
+          ],
+          "PublishedDate": "2020-07-14T14:15:17.667Z",
+          "LastModifiedDate": "2024-11-21T05:06:05.903Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "libmount1@2.41-5",
+          "PkgName": "libmount1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libmount1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6d2d7374cd54451e"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:2d62c4a460e1aa84eb911a72f2c1ce4b4bd28c314357ab00cad6eb18a8a86e17",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "libmount1@2.41-5",
+          "PkgName": "libmount1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libmount1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "6d2d7374cd54451e"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:99e105e271480db8cb72f62f243e1f2bf3dc70c7f039570bfb95f4796c657f0c",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-6141",
+          "PkgID": "libncursesw6@6.5+20250216-2",
+          "PkgName": "libncursesw6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libncursesw6@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "9ab389651a2b5886"
+          },
+          "InstalledVersion": "6.5+20250216-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-6141",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:86bca0d65be88e6d436b5ff016b8f97cee6234202dccfbc412f029ba1cca5dce",
+          "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
+          "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119",
+            "CWE-121"
+          ],
+          "VendorSeverity": {
+            "photon": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-6141",
+            "https://invisible-island.net/ncurses/NEWS.html#index-t20250329",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00107.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00109.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00114.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-6141",
+            "https://vuldb.com/?ctiid.312610",
+            "https://vuldb.com/?id.312610",
+            "https://vuldb.com/?submit.593000",
+            "https://www.cve.org/CVERecord?id=CVE-2025-6141",
+            "https://www.gnu.org/"
+          ],
+          "PublishedDate": "2025-06-16T22:16:41.527Z",
+          "LastModifiedDate": "2025-06-17T20:50:23.507Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "libsmartcols1@2.41-5",
+          "PkgName": "libsmartcols1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsmartcols1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bdd963006efde917"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:1cb12652a88160e1f78568c597094ba5d2fd4a5a08f16db1ea93c60b92b7b808",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "libsmartcols1@2.41-5",
+          "PkgName": "libsmartcols1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsmartcols1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "bdd963006efde917"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:9a16900816e3e233f0c1c657cf643e910afdc8d8678a95b64bad0c88b6c6e0c3",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-7709",
+          "PkgID": "libsqlite3-0@3.46.1-7",
+          "PkgName": "libsqlite3-0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsqlite3-0@3.46.1-7?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d3b12dcb7bd33f74"
+          },
+          "InstalledVersion": "3.46.1-7",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-7709",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:05f418ea386bc784dd88f7864f8bcaedb2106d0fdcece7cb83c2caf10772427c",
+          "Title": "An integer overflow exists in the  FTS5 https://sqlite.org/fts5.html e ...",
+          "Description": "An integer overflow exists in the  FTS5 https://sqlite.org/fts5.html  extension. It occurs when the size of an array of tombstone pointers is calculated and truncated into a 32-bit integer. A pointer to partially controlled data can then be written out of bounds.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "photon": 3,
+            "ubuntu": 2
+          },
+          "References": [
+            "http://www.openwall.com/lists/oss-security/2025/09/06/2",
+            "http://www.openwall.com/lists/oss-security/2025/11/18/10",
+            "https://github.com/google/security-research/security/advisories/GHSA-v2c8-vqqp-hv3g",
+            "https://ubuntu.com/security/notices/USN-7751-1",
+            "https://www.cve.org/CVERecord?id=CVE-2025-7709"
+          ],
+          "PublishedDate": "2025-09-08T15:15:38.18Z",
+          "LastModifiedDate": "2025-11-18T23:15:58.5Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2021-45346",
+          "PkgID": "libsqlite3-0@3.46.1-7",
+          "PkgName": "libsqlite3-0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsqlite3-0@3.46.1-7?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d3b12dcb7bd33f74"
+          },
+          "InstalledVersion": "3.46.1-7",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-45346",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:d25b7c630c9026398ef38c15fa4e95f9fc9af54f6683d41f0136e20d298fce5b",
+          "Title": "sqlite: crafted SQL query allows a malicious user to obtain sensitive information",
+          "Description": "A Memory Leak vulnerability exists in SQLite Project SQLite3 3.35.1 and 3.37.0 via maliciously crafted SQL Queries (made via editing the Database File), it is possible to query a record, and leak subsequent bytes of memory that extend beyond the record, which could let a malicious user obtain sensitive information. NOTE: The developer disputes this as a vulnerability stating that If you give SQLite a corrupted database file and submit a query against the database, it might read parts of the database that you did not intend or expect.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-401"
+          ],
+          "VendorSeverity": {
+            "bitnami": 2,
+            "debian": 1,
+            "nvd": 2,
+            "redhat": 1
+          },
+          "CVSS": {
+            "bitnami": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 4.3
+            },
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:S/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "V2Score": 4,
+              "V3Score": 4.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "V3Score": 4.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2021-45346",
+            "https://github.com/guyinatuxedo/sqlite3_record_leaking",
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-45346",
+            "https://security.netapp.com/advisory/ntap-20220303-0001/",
+            "https://sqlite.org/forum/forumpost/056d557c2f8c452ed5",
+            "https://sqlite.org/forum/forumpost/53de8864ba114bf6",
+            "https://www.cve.org/CVERecord?id=CVE-2021-45346",
+            "https://www.sqlite.org/cves.html#status_of_recent_sqlite_cves"
+          ],
+          "PublishedDate": "2022-02-14T19:15:07.793Z",
+          "LastModifiedDate": "2024-11-21T06:32:07.577Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2013-4392",
+          "PkgID": "libsystemd0@257.8-1~deb13u2",
+          "PkgName": "libsystemd0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsystemd0@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b19608333503a8c4"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2013-4392",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:cfac47fbbc0cd5b88ae8869781a2465330746bd11a3ee1711d000ab0879fe4cc",
+          "Title": "systemd: TOCTOU race condition when updating file permissions and SELinux security contexts",
+          "Description": "systemd, when updating file permissions, allows local users to change the permissions and SELinux security contexts for arbitrary files via a symlink attack on unspecified files.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-59"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 1,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+              "V2Score": 3.3
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+              "V2Score": 3.3
+            }
+          },
+          "References": [
+            "http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=725357",
+            "http://www.openwall.com/lists/oss-security/2013/10/01/9",
+            "https://access.redhat.com/security/cve/CVE-2013-4392",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=859060",
+            "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+            "https://www.cve.org/CVERecord?id=CVE-2013-4392"
+          ],
+          "PublishedDate": "2013-10-28T22:55:03.773Z",
+          "LastModifiedDate": "2025-06-09T16:15:23.763Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31437",
+          "PkgID": "libsystemd0@257.8-1~deb13u2",
+          "PkgName": "libsystemd0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsystemd0@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b19608333503a8c4"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31437",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:853e7b6c74bd0647258f987c94fff4f66ee0a0e06f49fd43939a1df63bfe3f89",
+          "Title": "An issue was discovered in systemd 253. An attacker can modify a seale ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can modify a sealed log file such that, in some views, not all existing and sealed log messages are displayed. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.657Z",
+          "LastModifiedDate": "2025-01-03T20:15:26.457Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31438",
+          "PkgID": "libsystemd0@257.8-1~deb13u2",
+          "PkgName": "libsystemd0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsystemd0@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b19608333503a8c4"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31438",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:2d1a4804aef48408391d455a2d97d69916225882a012d2ed8d37c46d237562da",
+          "Title": "An issue was discovered in systemd 253. An attacker can truncate a sea ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can truncate a sealed log file and then resume log sealing such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/pull/28886",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.707Z",
+          "LastModifiedDate": "2024-11-21T08:01:51.953Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31439",
+          "PkgID": "libsystemd0@257.8-1~deb13u2",
+          "PkgName": "libsystemd0",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libsystemd0@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "b19608333503a8c4"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31439",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:61619fdb221eee1fd9887c5e0fde37c54869bc95076b483c4d7561d945487109",
+          "Title": "An issue was discovered in systemd 253. An attacker can modify the con ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can modify the contents of past events in a sealed log file and then adjust the file such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/pull/28885",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.753Z",
+          "LastModifiedDate": "2024-11-21T08:01:52.097Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-6141",
+          "PkgID": "libtinfo6@6.5+20250216-2",
+          "PkgName": "libtinfo6",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libtinfo6@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "39109c87ce11f4ff"
+          },
+          "InstalledVersion": "6.5+20250216-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-6141",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:a469a3a90695ba6f65ef81fea32b8d7a71328a286c27d8238fc8aebea0f751ad",
+          "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
+          "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119",
+            "CWE-121"
+          ],
+          "VendorSeverity": {
+            "photon": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-6141",
+            "https://invisible-island.net/ncurses/NEWS.html#index-t20250329",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00107.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00109.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00114.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-6141",
+            "https://vuldb.com/?ctiid.312610",
+            "https://vuldb.com/?id.312610",
+            "https://vuldb.com/?submit.593000",
+            "https://www.cve.org/CVERecord?id=CVE-2025-6141",
+            "https://www.gnu.org/"
+          ],
+          "PublishedDate": "2025-06-16T22:16:41.527Z",
+          "LastModifiedDate": "2025-06-17T20:50:23.507Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2013-4392",
+          "PkgID": "libudev1@257.8-1~deb13u2",
+          "PkgName": "libudev1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libudev1@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1a4e2b5bbb145a62"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2013-4392",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:d5c14519124bd98f68a2f6e7df0f1894aa85532700e839be6f2481ca3fd77ea2",
+          "Title": "systemd: TOCTOU race condition when updating file permissions and SELinux security contexts",
+          "Description": "systemd, when updating file permissions, allows local users to change the permissions and SELinux security contexts for arbitrary files via a symlink attack on unspecified files.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-59"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 1,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+              "V2Score": 3.3
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+              "V2Score": 3.3
+            }
+          },
+          "References": [
+            "http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=725357",
+            "http://www.openwall.com/lists/oss-security/2013/10/01/9",
+            "https://access.redhat.com/security/cve/CVE-2013-4392",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=859060",
+            "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+            "https://www.cve.org/CVERecord?id=CVE-2013-4392"
+          ],
+          "PublishedDate": "2013-10-28T22:55:03.773Z",
+          "LastModifiedDate": "2025-06-09T16:15:23.763Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31437",
+          "PkgID": "libudev1@257.8-1~deb13u2",
+          "PkgName": "libudev1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libudev1@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1a4e2b5bbb145a62"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31437",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:bc97aedd7944116bb8a464a67b8af86cd0e8577f9d4ac2c872e258920aba0c62",
+          "Title": "An issue was discovered in systemd 253. An attacker can modify a seale ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can modify a sealed log file such that, in some views, not all existing and sealed log messages are displayed. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.657Z",
+          "LastModifiedDate": "2025-01-03T20:15:26.457Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31438",
+          "PkgID": "libudev1@257.8-1~deb13u2",
+          "PkgName": "libudev1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libudev1@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1a4e2b5bbb145a62"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31438",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:48733eb4a6e202b99204a54426f2951254d31ae37bc9a95dc9545cd23d923606",
+          "Title": "An issue was discovered in systemd 253. An attacker can truncate a sea ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can truncate a sealed log file and then resume log sealing such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/pull/28886",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.707Z",
+          "LastModifiedDate": "2024-11-21T08:01:51.953Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2023-31439",
+          "PkgID": "libudev1@257.8-1~deb13u2",
+          "PkgName": "libudev1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libudev1@257.8-1~deb13u2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "1a4e2b5bbb145a62"
+          },
+          "InstalledVersion": "257.8-1~deb13u2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-31439",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:d84758caafd7008fd7415048d4214bebed384b04f1ef24fc70f315f759d4de97",
+          "Title": "An issue was discovered in systemd 253. An attacker can modify the con ...",
+          "Description": "An issue was discovered in systemd 253. An attacker can modify the contents of past events in a sealed log file and then adjust the file such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\"",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-354"
+          ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://github.com/kastel-security/Journald",
+            "https://github.com/kastel-security/Journald/blob/main/journald-publication.pdf",
+            "https://github.com/systemd/systemd/pull/28885",
+            "https://github.com/systemd/systemd/releases"
+          ],
+          "PublishedDate": "2023-06-13T17:15:14.753Z",
+          "LastModifiedDate": "2024-11-21T08:01:52.097Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "libuuid1@2.41-5",
+          "PkgName": "libuuid1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libuuid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e68ae51900aac46d"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:57cc87e593e1f27009a90c9a4ca44b1c77486850a72de4a219f1b39de6ca21fb",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "libuuid1@2.41-5",
+          "PkgName": "libuuid1",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/libuuid1@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "e68ae51900aac46d"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:1f385913e6d7e933f4d90a107b23d43673e5cebcb783751cc9ac1e1cf9176665",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "login@1:4.16.0-2+really2.41-5",
+          "PkgName": "login",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/login@4.16.0-2%2Breally2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "9a6da06303db8b93"
+          },
+          "InstalledVersion": "1:4.16.0-2+really2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:76bbc366248cbed933eb284e06c79759a396fa2385796c57cb6c8ddd05c29dee",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "login@1:4.16.0-2+really2.41-5",
+          "PkgName": "login",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/login@4.16.0-2%2Breally2.41-5?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "9a6da06303db8b93"
+          },
+          "InstalledVersion": "1:4.16.0-2+really2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:c6bf0cab4a4dba4f964372f503ea5f99f78545b45f6e3f9a7b0e2681938a8420",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2007-5686",
+          "PkgID": "login.defs@1:4.17.4-2",
+          "PkgName": "login.defs",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/login.defs@4.17.4-2?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "b2ebc9108569350a"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2007-5686",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:7dc88e5942642513a32736a89c696476940c074bac3dda290fc440b6dbbd575b",
+          "Title": "initscripts in rPath Linux 1 sets insecure permissions for the /var/lo ...",
+          "Description": "initscripts in rPath Linux 1 sets insecure permissions for the /var/log/btmp file, which allows local users to obtain sensitive information regarding authentication attempts.  NOTE: because sshd detects the insecure permissions and does not log certain events, this also prevents sshd from logging failed authentication attempts by remote attackers.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-264"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
+              "V2Score": 4.9
+            }
+          },
+          "References": [
+            "http://secunia.com/advisories/27215",
+            "http://www.securityfocus.com/archive/1/482129/100/100/threaded",
+            "http://www.securityfocus.com/archive/1/482857/100/0/threaded",
+            "http://www.securityfocus.com/bid/26048",
+            "http://www.vupen.com/english/advisories/2007/3474",
+            "https://issues.rpath.com/browse/RPL-1825"
+          ],
+          "PublishedDate": "2007-10-28T17:08:00Z",
+          "LastModifiedDate": "2024-11-21T00:38:27.587Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-56433",
+          "PkgID": "login.defs@1:4.17.4-2",
+          "PkgName": "login.defs",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/login.defs@4.17.4-2?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "b2ebc9108569350a"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-56433",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:f9afbb12338c8bb68b5f7062011ae049998da5c5f0105a57007ab4c55dda75ea",
+          "Title": "shadow-utils: Default subordinate ID configuration in /etc/login.defs could lead to compromise",
+          "Description": "shadow-utils (aka shadow) 4.4 through 4.17.0 establishes a default /etc/subuid behavior (e.g., uid 100000 through 165535 for the first user account) that can realistically conflict with the uids of users defined on locally administered networks, potentially leading to account takeover, e.g., by leveraging newuidmap for access to an NFS home directory (or same-host resources in the case of remote logins by these local network users). NOTE: it may also be argued that system administrators should not have assigned uids, within local networks, that are within the range that can occur in /etc/subuid.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-1188"
+          ],
+          "VendorSeverity": {
+            "alma": 1,
+            "azure": 1,
+            "oracle-oval": 1,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N",
+              "V3Score": 3.6
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2025:20145",
+            "https://access.redhat.com/security/cve/CVE-2024-56433",
+            "https://bugzilla.redhat.com/2334165",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2334165",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-56433",
+            "https://errata.almalinux.org/10/ALSA-2025-20145.html",
+            "https://errata.rockylinux.org/RLSA-2025:20145",
+            "https://github.com/shadow-maint/shadow/blob/e2512d5741d4a44bdd81a8c2d0029b6222728cf0/etc/login.defs#L238-L241",
+            "https://github.com/shadow-maint/shadow/issues/1157",
+            "https://github.com/shadow-maint/shadow/releases/tag/4.4",
+            "https://linux.oracle.com/cve/CVE-2024-56433.html",
+            "https://linux.oracle.com/errata/ELSA-2025-20559-0.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-56433",
+            "https://www.cve.org/CVERecord?id=CVE-2024-56433"
+          ],
+          "PublishedDate": "2024-12-26T09:15:07.267Z",
+          "LastModifiedDate": "2024-12-26T09:15:07.267Z"
+        },
+        {
+          "VulnerabilityID": "TEMP-0628843-DBAD28",
+          "PkgID": "login.defs@1:4.17.4-2",
+          "PkgName": "login.defs",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/login.defs@4.17.4-2?arch=all\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "b2ebc9108569350a"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0628843-DBAD28",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:ef66ad9de339062e8cffb576cc96b9c81061b9d60463e3f11c271af997c8cd06",
+          "Title": "[more related to CVE-2005-4890]",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1
+          }
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "mount@2.41-5",
+          "PkgName": "mount",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/mount@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c6fdc5cf989db569"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b3e04616eba5044ad92d9462857617e81484c250328748df2d1c9370f5591462",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "mount@2.41-5",
+          "PkgName": "mount",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/mount@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c6fdc5cf989db569"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:fcfbc707393372ab3ae2f4b84c5925a048be9a533e46b80669d0f00d79de1771",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-6141",
+          "PkgID": "ncurses-base@6.5+20250216-2",
+          "PkgName": "ncurses-base",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/ncurses-base@6.5%2B20250216-2?arch=all\u0026distro=debian-13.1",
+            "UID": "76a1fb5936f344dc"
+          },
+          "InstalledVersion": "6.5+20250216-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-6141",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:f26eb7682eaf06401b988824963dd218701632c686783dba51cbd128131c60e0",
+          "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
+          "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119",
+            "CWE-121"
+          ],
+          "VendorSeverity": {
+            "photon": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-6141",
+            "https://invisible-island.net/ncurses/NEWS.html#index-t20250329",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00107.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00109.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00114.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-6141",
+            "https://vuldb.com/?ctiid.312610",
+            "https://vuldb.com/?id.312610",
+            "https://vuldb.com/?submit.593000",
+            "https://www.cve.org/CVERecord?id=CVE-2025-6141",
+            "https://www.gnu.org/"
+          ],
+          "PublishedDate": "2025-06-16T22:16:41.527Z",
+          "LastModifiedDate": "2025-06-17T20:50:23.507Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-6141",
+          "PkgID": "ncurses-bin@6.5+20250216-2",
+          "PkgName": "ncurses-bin",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/ncurses-bin@6.5%2B20250216-2?arch=amd64\u0026distro=debian-13.1",
+            "UID": "d03e89ad6a7a5243"
+          },
+          "InstalledVersion": "6.5+20250216-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-6141",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:9dd0f436cad5ec4713df422acab08e0c6aefa52e416e2c83f6b4e96b7c509cda",
+          "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
+          "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-119",
+            "CWE-121"
+          ],
+          "VendorSeverity": {
+            "photon": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-6141",
+            "https://invisible-island.net/ncurses/NEWS.html#index-t20250329",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00107.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00109.html",
+            "https://lists.gnu.org/archive/html/bug-ncurses/2025-03/msg00114.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-6141",
+            "https://vuldb.com/?ctiid.312610",
+            "https://vuldb.com/?id.312610",
+            "https://vuldb.com/?submit.593000",
+            "https://www.cve.org/CVERecord?id=CVE-2025-6141",
+            "https://www.gnu.org/"
+          ],
+          "PublishedDate": "2025-06-16T22:16:41.527Z",
+          "LastModifiedDate": "2025-06-17T20:50:23.507Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2007-5686",
+          "PkgID": "passwd@1:4.17.4-2",
+          "PkgName": "passwd",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/passwd@4.17.4-2?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "5e15080d1eeaf8e8"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2007-5686",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:91cb27e0cf7e9a8a6327e8db829fb914ed16841cc0b38c673d7e09778f8d5cfc",
+          "Title": "initscripts in rPath Linux 1 sets insecure permissions for the /var/lo ...",
+          "Description": "initscripts in rPath Linux 1 sets insecure permissions for the /var/log/btmp file, which allows local users to obtain sensitive information regarding authentication attempts.  NOTE: because sshd detects the insecure permissions and does not log certain events, this also prevents sshd from logging failed authentication attempts by remote attackers.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-264"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
+              "V2Score": 4.9
+            }
+          },
+          "References": [
+            "http://secunia.com/advisories/27215",
+            "http://www.securityfocus.com/archive/1/482129/100/100/threaded",
+            "http://www.securityfocus.com/archive/1/482857/100/0/threaded",
+            "http://www.securityfocus.com/bid/26048",
+            "http://www.vupen.com/english/advisories/2007/3474",
+            "https://issues.rpath.com/browse/RPL-1825"
+          ],
+          "PublishedDate": "2007-10-28T17:08:00Z",
+          "LastModifiedDate": "2024-11-21T00:38:27.587Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-56433",
+          "PkgID": "passwd@1:4.17.4-2",
+          "PkgName": "passwd",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/passwd@4.17.4-2?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "5e15080d1eeaf8e8"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-56433",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:a92a3542ec4a8e8aee76f7e87f540780b767cba7d165772e6472e876d80837fa",
+          "Title": "shadow-utils: Default subordinate ID configuration in /etc/login.defs could lead to compromise",
+          "Description": "shadow-utils (aka shadow) 4.4 through 4.17.0 establishes a default /etc/subuid behavior (e.g., uid 100000 through 165535 for the first user account) that can realistically conflict with the uids of users defined on locally administered networks, potentially leading to account takeover, e.g., by leveraging newuidmap for access to an NFS home directory (or same-host resources in the case of remote logins by these local network users). NOTE: it may also be argued that system administrators should not have assigned uids, within local networks, that are within the range that can occur in /etc/subuid.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-1188"
+          ],
+          "VendorSeverity": {
+            "alma": 1,
+            "azure": 1,
+            "oracle-oval": 1,
+            "redhat": 1,
+            "rocky": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N",
+              "V3Score": 3.6
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2025:20145",
+            "https://access.redhat.com/security/cve/CVE-2024-56433",
+            "https://bugzilla.redhat.com/2334165",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2334165",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-56433",
+            "https://errata.almalinux.org/10/ALSA-2025-20145.html",
+            "https://errata.rockylinux.org/RLSA-2025:20145",
+            "https://github.com/shadow-maint/shadow/blob/e2512d5741d4a44bdd81a8c2d0029b6222728cf0/etc/login.defs#L238-L241",
+            "https://github.com/shadow-maint/shadow/issues/1157",
+            "https://github.com/shadow-maint/shadow/releases/tag/4.4",
+            "https://linux.oracle.com/cve/CVE-2024-56433.html",
+            "https://linux.oracle.com/errata/ELSA-2025-20559-0.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-56433",
+            "https://www.cve.org/CVERecord?id=CVE-2024-56433"
+          ],
+          "PublishedDate": "2024-12-26T09:15:07.267Z",
+          "LastModifiedDate": "2024-12-26T09:15:07.267Z"
+        },
+        {
+          "VulnerabilityID": "TEMP-0628843-DBAD28",
+          "PkgID": "passwd@1:4.17.4-2",
+          "PkgName": "passwd",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/passwd@4.17.4-2?arch=amd64\u0026distro=debian-13.1\u0026epoch=1",
+            "UID": "5e15080d1eeaf8e8"
+          },
+          "InstalledVersion": "1:4.17.4-2",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0628843-DBAD28",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:375c340829b5d6ee19bf5f98a5b7eb99c8843ca5b61dde83ce303249ee977df1",
+          "Title": "[more related to CVE-2005-4890]",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1
+          }
+        },
+        {
+          "VulnerabilityID": "CVE-2011-4116",
+          "PkgID": "perl-base@5.40.1-6",
+          "PkgName": "perl-base",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/perl-base@5.40.1-6?arch=amd64\u0026distro=debian-13.1",
+            "UID": "17f06da2c02a11c6"
+          },
+          "InstalledVersion": "5.40.1-6",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-4116",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:c65c0dd1c2d27c143540b41ca980ff64df9e69146934d12037ff3ef0d49a133a",
+          "Title": "perl: File:: Temp insecure temporary file handling",
+          "Description": "_is_safe in the File::Temp module for Perl does not properly handle symlinks.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-59"
+          ],
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:S/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+              "V2Score": 1.5,
+              "V3Score": 3.3
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
+              "V2Score": 1.9
+            }
+          },
+          "References": [
+            "http://www.openwall.com/lists/oss-security/2011/11/04/2",
+            "http://www.openwall.com/lists/oss-security/2011/11/04/4",
+            "https://access.redhat.com/security/cve/CVE-2011-4116",
+            "https://github.com/Perl-Toolchain-Gang/File-Temp/issues/14",
+            "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+            "https://rt.cpan.org/Public/Bug/Display.html?id=69106",
+            "https://seclists.org/oss-sec/2011/q4/238",
+            "https://www.cve.org/CVERecord?id=CVE-2011-4116"
+          ],
+          "PublishedDate": "2020-01-31T18:15:11.343Z",
+          "LastModifiedDate": "2025-08-04T19:04:38.29Z"
+        },
+        {
+          "VulnerabilityID": "TEMP-0517018-A83CE6",
+          "PkgID": "sysvinit-utils@3.14-4",
+          "PkgName": "sysvinit-utils",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/sysvinit-utils@3.14-4?arch=amd64\u0026distro=debian-13.1",
+            "UID": "c7e8999242a896a1"
+          },
+          "InstalledVersion": "3.14-4",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0517018-A83CE6",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:3aff6f43d3a9928992649e2c508318943b7822e3a0cfc05c96e5b3c9fdd9ef84",
+          "Title": "[sysvinit: no-root option in expert installer exposes locally exploitable security flaw]",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1
+          }
+        },
+        {
+          "VulnerabilityID": "CVE-2005-2541",
+          "PkgID": "tar@1.35+dfsg-3.1",
+          "PkgName": "tar",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/tar@1.35%2Bdfsg-3.1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "50aee76d081ea925"
+          },
+          "InstalledVersion": "1.35+dfsg-3.1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2005-2541",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:a7d1496daec776e1fd2dbcd22f31e8213bb136a4c59162a51a7254adf3dc927a",
+          "Title": "tar: does not properly warn the user when extracting setuid or setgid files",
+          "Description": "Tar 1.15.1 does not properly warn the user when extracting setuid or setgid files, which may allow local users or remote attackers to gain privileges.",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1,
+            "nvd": 3,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+              "V2Score": 10
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "V3Score": 7
+            }
+          },
+          "References": [
+            "http://marc.info/?l=bugtraq\u0026m=112327628230258\u0026w=2",
+            "https://access.redhat.com/security/cve/CVE-2005-2541",
+            "https://lists.apache.org/thread.html/rc713534b10f9daeee2e0990239fa407e2118e4aa9e88a7041177497c%40%3Cissues.guacamole.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
+            "https://www.cve.org/CVERecord?id=CVE-2005-2541"
+          ],
+          "PublishedDate": "2005-08-10T04:00:00Z",
+          "LastModifiedDate": "2025-04-03T01:03:51.193Z"
+        },
+        {
+          "VulnerabilityID": "TEMP-0290435-0B57B5",
+          "PkgID": "tar@1.35+dfsg-3.1",
+          "PkgName": "tar",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/tar@1.35%2Bdfsg-3.1?arch=amd64\u0026distro=debian-13.1",
+            "UID": "50aee76d081ea925"
+          },
+          "InstalledVersion": "1.35+dfsg-3.1",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0290435-0B57B5",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:b6b1df00eab3b8473b017be2aaaf8bbac45437bd57b202ea325a3a609cd083cb",
+          "Title": "[tar's rmt command may have undesired side effects]",
+          "Severity": "LOW",
+          "VendorSeverity": {
+            "debian": 1
+          }
+        },
+        {
+          "VulnerabilityID": "CVE-2025-14104",
+          "PkgID": "util-linux@2.41-5",
+          "PkgName": "util-linux",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/util-linux@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "38be4846f19b7fa"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-14104",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:483c8625094eb76c06ffa849836f4559e31dbd8c924d008bf2d4b879562d4589",
+          "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
+          "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-125"
+          ],
+          "VendorSeverity": {
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
+              "V3Score": 6.1
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-14104",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2419369",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-14104",
+            "https://www.cve.org/CVERecord?id=CVE-2025-14104"
+          ],
+          "PublishedDate": "2025-12-05T17:16:03.117Z",
+          "LastModifiedDate": "2025-12-05T17:16:03.117Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2022-0563",
+          "PkgID": "util-linux@2.41-5",
+          "PkgName": "util-linux",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/util-linux@2.41-5?arch=amd64\u0026distro=debian-13.1",
+            "UID": "38be4846f19b7fa"
+          },
+          "InstalledVersion": "2.41-5",
+          "Status": "affected",
+          "Layer": {
+            "DiffID": "sha256:d7c97cb6f1fe7cae982649e9f55efe201212e8acaa64bd668c083b204e4efd4c"
+          },
+          "SeveritySource": "debian",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-0563",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Fingerprint": "sha256:dbaa0746aed747e0a04f001e6d5b52f1dd33a342e87fa8a05025cc47a33c430d",
+          "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
+          "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-209"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "debian": 1,
+            "nvd": 2,
+            "photon": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V2Score": 1.9,
+              "V3Score": 5.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "V3Score": 5.5
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2022-0563",
+            "https://blog.trailofbits.com/2023/02/16/suid-logic-bug-linux-readline/",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w%40ws.net.home/T/#u",
+            "https://lore.kernel.org/util-linux/20220214110609.msiwlm457ngoic6w@ws.net.home/T/#u",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-0563",
+            "https://security.gentoo.org/glsa/202401-08",
+            "https://security.netapp.com/advisory/ntap-20220331-0002/",
+            "https://www.cve.org/CVERecord?id=CVE-2022-0563"
+          ],
+          "PublishedDate": "2022-02-21T19:15:08.393Z",
+          "LastModifiedDate": "2025-06-09T16:15:33.237Z"
+        }
+      ]
+    },
+    {
+      "Target": "Python",
+      "Class": "lang-pkgs",
+      "Type": "python-pkg",
+      "Packages": [
+        {
+          "Name": "Pygments",
+          "Identifier": {
+            "PURL": "pkg:pypi/pygments@2.19.2",
+            "UID": "9dc2a8c3fc0de6d8"
+          },
+          "Version": "2.19.2",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pygments-2.19.2.dist-info/METADATA"
+        },
+        {
+          "Name": "Pygments",
+          "Identifier": {
+            "PURL": "pkg:pypi/pygments@2.19.2",
+            "UID": "5ed5c9f83367631"
+          },
+          "Version": "2.19.2",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pygments-2.19.2.dist-info/METADATA"
+        },
+        {
+          "Name": "SQLAlchemy",
+          "Identifier": {
+            "PURL": "pkg:pypi/sqlalchemy@2.0.44",
+            "UID": "4c74192b2d7ad58b"
+          },
+          "Version": "2.0.44",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/sqlalchemy-2.0.44.dist-info/METADATA"
+        },
+        {
+          "Name": "SQLAlchemy",
+          "Identifier": {
+            "PURL": "pkg:pypi/sqlalchemy@2.0.44",
+            "UID": "35d9e8f7cf092bd6"
+          },
+          "Version": "2.0.44",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/sqlalchemy-2.0.44.dist-info/METADATA"
+        },
+        {
+          "Name": "annotated-doc",
+          "Identifier": {
+            "PURL": "pkg:pypi/annotated-doc@0.0.4",
+            "UID": "d35fe0622d36c713"
+          },
+          "Version": "0.0.4",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/annotated_doc-0.0.4.dist-info/METADATA"
+        },
+        {
+          "Name": "annotated-doc",
+          "Identifier": {
+            "PURL": "pkg:pypi/annotated-doc@0.0.4",
+            "UID": "48f6a681be485902"
+          },
+          "Version": "0.0.4",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/annotated_doc-0.0.4.dist-info/METADATA"
+        },
+        {
+          "Name": "annotated-types",
+          "Identifier": {
+            "PURL": "pkg:pypi/annotated-types@0.7.0",
+            "UID": "b3accbbcb355fed2"
+          },
+          "Version": "0.7.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/annotated_types-0.7.0.dist-info/METADATA"
+        },
+        {
+          "Name": "annotated-types",
+          "Identifier": {
+            "PURL": "pkg:pypi/annotated-types@0.7.0",
+            "UID": "13bb47f8220c3192"
+          },
+          "Version": "0.7.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/annotated_types-0.7.0.dist-info/METADATA"
+        },
+        {
+          "Name": "anyio",
+          "Identifier": {
+            "PURL": "pkg:pypi/anyio@4.12.0",
+            "UID": "9e381ea89cfb4a24"
+          },
+          "Version": "4.12.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/anyio-4.12.0.dist-info/METADATA"
+        },
+        {
+          "Name": "anyio",
+          "Identifier": {
+            "PURL": "pkg:pypi/anyio@4.12.0",
+            "UID": "4ae40490b759a33b"
+          },
+          "Version": "4.12.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/anyio-4.12.0.dist-info/METADATA"
+        },
+        {
+          "Name": "autocommand",
+          "Identifier": {
+            "PURL": "pkg:pypi/autocommand@2.2.2",
+            "UID": "4d240d00ee034bda"
+          },
+          "Version": "2.2.2",
+          "Licenses": [
+            "LGPL-3.0-only"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/autocommand-2.2.2.dist-info/METADATA"
+        },
+        {
+          "Name": "backports.tarfile",
+          "Identifier": {
+            "PURL": "pkg:pypi/backports.tarfile@1.2.0",
+            "UID": "2cb6077992cd5766"
+          },
+          "Version": "1.2.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/backports.tarfile-1.2.0.dist-info/METADATA"
+        },
+        {
+          "Name": "certifi",
+          "Identifier": {
+            "PURL": "pkg:pypi/certifi@2025.11.12",
+            "UID": "197a05ee7abec61e"
+          },
+          "Version": "2025.11.12",
+          "Licenses": [
+            "MPL-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/certifi-2025.11.12.dist-info/METADATA"
+        },
+        {
+          "Name": "certifi",
+          "Identifier": {
+            "PURL": "pkg:pypi/certifi@2025.11.12",
+            "UID": "94a24d519a363e56"
+          },
+          "Version": "2025.11.12",
+          "Licenses": [
+            "MPL-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/certifi-2025.11.12.dist-info/METADATA"
+        },
+        {
+          "Name": "click",
+          "Identifier": {
+            "PURL": "pkg:pypi/click@8.1.8",
+            "UID": "385443eb0b004abf"
+          },
+          "Version": "8.1.8",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/click-8.1.8.dist-info/METADATA"
+        },
+        {
+          "Name": "click",
+          "Identifier": {
+            "PURL": "pkg:pypi/click@8.3.1",
+            "UID": "24ce440ed470b89c"
+          },
+          "Version": "8.3.1",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/click-8.3.1.dist-info/METADATA"
+        },
+        {
+          "Name": "coverage",
+          "Identifier": {
+            "PURL": "pkg:pypi/coverage@7.10.7",
+            "UID": "d72a5e4abd3008b7"
+          },
+          "Version": "7.10.7",
+          "Licenses": [
+            "Apache-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/coverage-7.10.7.dist-info/METADATA"
+        },
+        {
+          "Name": "coverage",
+          "Identifier": {
+            "PURL": "pkg:pypi/coverage@7.13.0",
+            "UID": "6f1dfc8a84458235"
+          },
+          "Version": "7.13.0",
+          "Licenses": [
+            "Apache-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/coverage-7.13.0.dist-info/METADATA"
+        },
+        {
+          "Name": "exceptiongroup",
+          "Identifier": {
+            "PURL": "pkg:pypi/exceptiongroup@1.3.1",
+            "UID": "b40817ba8bcecdea"
+          },
+          "Version": "1.3.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/exceptiongroup-1.3.1.dist-info/METADATA"
+        },
+        {
+          "Name": "fastapi",
+          "Identifier": {
+            "PURL": "pkg:pypi/fastapi@0.124.0",
+            "UID": "534ca4905293de2e"
+          },
+          "Version": "0.124.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/fastapi-0.124.0.dist-info/METADATA"
+        },
+        {
+          "Name": "fastapi",
+          "Identifier": {
+            "PURL": "pkg:pypi/fastapi@0.124.0",
+            "UID": "b46bae901fe29270"
+          },
+          "Version": "0.124.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/fastapi-0.124.0.dist-info/METADATA"
+        },
+        {
+          "Name": "flake8",
+          "Identifier": {
+            "PURL": "pkg:pypi/flake8@7.3.0",
+            "UID": "837add2621a0fc8c"
+          },
+          "Version": "7.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/flake8-7.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "flake8",
+          "Identifier": {
+            "PURL": "pkg:pypi/flake8@7.3.0",
+            "UID": "eac3cfa51c79c788"
+          },
+          "Version": "7.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/flake8-7.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "greenlet",
+          "Identifier": {
+            "PURL": "pkg:pypi/greenlet@3.2.4",
+            "UID": "6f73771be3776f66"
+          },
+          "Version": "3.2.4",
+          "Licenses": [
+            "MIT AND Python-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/greenlet-3.2.4.dist-info/METADATA"
+        },
+        {
+          "Name": "greenlet",
+          "Identifier": {
+            "PURL": "pkg:pypi/greenlet@3.3.0",
+            "UID": "cc83d5e5fdc764c5"
+          },
+          "Version": "3.3.0",
+          "Licenses": [
+            "MIT AND Python-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/greenlet-3.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "h11",
+          "Identifier": {
+            "PURL": "pkg:pypi/h11@0.16.0",
+            "UID": "a9a666ee3b97f191"
+          },
+          "Version": "0.16.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/h11-0.16.0.dist-info/METADATA"
+        },
+        {
+          "Name": "h11",
+          "Identifier": {
+            "PURL": "pkg:pypi/h11@0.16.0",
+            "UID": "180e2afd8d277b14"
+          },
+          "Version": "0.16.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/h11-0.16.0.dist-info/METADATA"
+        },
+        {
+          "Name": "httpcore",
+          "Identifier": {
+            "PURL": "pkg:pypi/httpcore@1.0.9",
+            "UID": "7975a2aa3d44c598"
+          },
+          "Version": "1.0.9",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/httpcore-1.0.9.dist-info/METADATA"
+        },
+        {
+          "Name": "httpcore",
+          "Identifier": {
+            "PURL": "pkg:pypi/httpcore@1.0.9",
+            "UID": "ae3e22b5589272b2"
+          },
+          "Version": "1.0.9",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/httpcore-1.0.9.dist-info/METADATA"
+        },
+        {
+          "Name": "httpx",
+          "Identifier": {
+            "PURL": "pkg:pypi/httpx@0.28.1",
+            "UID": "68bf39f9752e1bec"
+          },
+          "Version": "0.28.1",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/httpx-0.28.1.dist-info/METADATA"
+        },
+        {
+          "Name": "httpx",
+          "Identifier": {
+            "PURL": "pkg:pypi/httpx@0.28.1",
+            "UID": "c06fbeabfc4e3038"
+          },
+          "Version": "0.28.1",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/httpx-0.28.1.dist-info/METADATA"
+        },
+        {
+          "Name": "idna",
+          "Identifier": {
+            "PURL": "pkg:pypi/idna@3.11",
+            "UID": "d2c3d0a247419f6f"
+          },
+          "Version": "3.11",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/idna-3.11.dist-info/METADATA"
+        },
+        {
+          "Name": "idna",
+          "Identifier": {
+            "PURL": "pkg:pypi/idna@3.11",
+            "UID": "b31a50249c46c263"
+          },
+          "Version": "3.11",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/idna-3.11.dist-info/METADATA"
+        },
+        {
+          "Name": "importlib_metadata",
+          "Identifier": {
+            "PURL": "pkg:pypi/importlib-metadata@8.0.0",
+            "UID": "6df1cd2be22b5f70"
+          },
+          "Version": "8.0.0",
+          "Licenses": [
+            "Apache-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata-8.0.0.dist-info/METADATA"
+        },
+        {
+          "Name": "inflect",
+          "Identifier": {
+            "PURL": "pkg:pypi/inflect@7.3.1",
+            "UID": "553e30ad6a570552"
+          },
+          "Version": "7.3.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/inflect-7.3.1.dist-info/METADATA"
+        },
+        {
+          "Name": "iniconfig",
+          "Identifier": {
+            "PURL": "pkg:pypi/iniconfig@2.1.0",
+            "UID": "1e17199fdc5809e6"
+          },
+          "Version": "2.1.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/iniconfig-2.1.0.dist-info/METADATA"
+        },
+        {
+          "Name": "iniconfig",
+          "Identifier": {
+            "PURL": "pkg:pypi/iniconfig@2.3.0",
+            "UID": "ea601eda3f552e3a"
+          },
+          "Version": "2.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/iniconfig-2.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "jaraco.collections",
+          "Identifier": {
+            "PURL": "pkg:pypi/jaraco.collections@5.1.0",
+            "UID": "f1a21b5c6aa6833d"
+          },
+          "Version": "5.1.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/jaraco.collections-5.1.0.dist-info/METADATA"
+        },
+        {
+          "Name": "jaraco.context",
+          "Identifier": {
+            "PURL": "pkg:pypi/jaraco.context@5.3.0",
+            "UID": "882c3c99f921cbd8"
+          },
+          "Version": "5.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "jaraco.functools",
+          "Identifier": {
+            "PURL": "pkg:pypi/jaraco.functools@4.0.1",
+            "UID": "6d7eb6ed066dbb39"
+          },
+          "Version": "4.0.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/jaraco.functools-4.0.1.dist-info/METADATA"
+        },
+        {
+          "Name": "jaraco.text",
+          "Identifier": {
+            "PURL": "pkg:pypi/jaraco.text@3.12.1",
+            "UID": "4cd1fb7e785efc3"
+          },
+          "Version": "3.12.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/jaraco.text-3.12.1.dist-info/METADATA"
+        },
+        {
+          "Name": "mccabe",
+          "Identifier": {
+            "PURL": "pkg:pypi/mccabe@0.7.0",
+            "UID": "17e2f8e01409676b"
+          },
+          "Version": "0.7.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/mccabe-0.7.0.dist-info/METADATA"
+        },
+        {
+          "Name": "mccabe",
+          "Identifier": {
+            "PURL": "pkg:pypi/mccabe@0.7.0",
+            "UID": "fd9fffb2819add6a"
+          },
+          "Version": "0.7.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/mccabe-0.7.0.dist-info/METADATA"
+        },
+        {
+          "Name": "more-itertools",
+          "Identifier": {
+            "PURL": "pkg:pypi/more-itertools@10.3.0",
+            "UID": "e9caaec2c8111432"
+          },
+          "Version": "10.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/more_itertools-10.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "packaging",
+          "Identifier": {
+            "PURL": "pkg:pypi/packaging@24.2",
+            "UID": "3cc7270b6ab52662"
+          },
+          "Version": "24.2",
+          "Licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/packaging-24.2.dist-info/METADATA"
+        },
+        {
+          "Name": "packaging",
+          "Identifier": {
+            "PURL": "pkg:pypi/packaging@25.0",
+            "UID": "bcbda8e16918e4f0"
+          },
+          "Version": "25.0",
+          "Licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/packaging-25.0.dist-info/METADATA"
+        },
+        {
+          "Name": "packaging",
+          "Identifier": {
+            "PURL": "pkg:pypi/packaging@25.0",
+            "UID": "2e0a4c9eee838727"
+          },
+          "Version": "25.0",
+          "Licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/packaging-25.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pip",
+          "Identifier": {
+            "PURL": "pkg:pypi/pip@23.0.1",
+            "UID": "db4b2871e1f85d98"
+          },
+          "Version": "23.0.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA"
+        },
+        {
+          "Name": "pip",
+          "Identifier": {
+            "PURL": "pkg:pypi/pip@24.0",
+            "UID": "cc9459dfee37b119"
+          },
+          "Version": "24.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pip-24.0.dist-info/METADATA"
+        },
+        {
+          "Name": "platformdirs",
+          "Identifier": {
+            "PURL": "pkg:pypi/platformdirs@4.2.2",
+            "UID": "881fb936154981f4"
+          },
+          "Version": "4.2.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/platformdirs-4.2.2.dist-info/METADATA"
+        },
+        {
+          "Name": "pluggy",
+          "Identifier": {
+            "PURL": "pkg:pypi/pluggy@1.6.0",
+            "UID": "84fc0dbbc2404d9f"
+          },
+          "Version": "1.6.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pluggy-1.6.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pluggy",
+          "Identifier": {
+            "PURL": "pkg:pypi/pluggy@1.6.0",
+            "UID": "bf6560de5dfc40ef"
+          },
+          "Version": "1.6.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pluggy-1.6.0.dist-info/METADATA"
+        },
+        {
+          "Name": "psycopg2-binary",
+          "Identifier": {
+            "PURL": "pkg:pypi/psycopg2-binary@2.9.11",
+            "UID": "2feab979bcb19ae7"
+          },
+          "Version": "2.9.11",
+          "Licenses": [
+            "LGPL-2.1-only"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA"
+        },
+        {
+          "Name": "psycopg2-binary",
+          "Identifier": {
+            "PURL": "pkg:pypi/psycopg2-binary@2.9.11",
+            "UID": "c05ea5579307e40b"
+          },
+          "Version": "2.9.11",
+          "Licenses": [
+            "LGPL-2.1-only"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA"
+        },
+        {
+          "Name": "pycodestyle",
+          "Identifier": {
+            "PURL": "pkg:pypi/pycodestyle@2.14.0",
+            "UID": "5bf80721a1e77590"
+          },
+          "Version": "2.14.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pycodestyle-2.14.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pycodestyle",
+          "Identifier": {
+            "PURL": "pkg:pypi/pycodestyle@2.14.0",
+            "UID": "88a344993b69670"
+          },
+          "Version": "2.14.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pycodestyle-2.14.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pydantic",
+          "Identifier": {
+            "PURL": "pkg:pypi/pydantic@2.12.5",
+            "UID": "321a3bc605a0daed"
+          },
+          "Version": "2.12.5",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pydantic-2.12.5.dist-info/METADATA"
+        },
+        {
+          "Name": "pydantic",
+          "Identifier": {
+            "PURL": "pkg:pypi/pydantic@2.12.5",
+            "UID": "6bfe1e7a9343afb1"
+          },
+          "Version": "2.12.5",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pydantic-2.12.5.dist-info/METADATA"
+        },
+        {
+          "Name": "pydantic_core",
+          "Identifier": {
+            "PURL": "pkg:pypi/pydantic-core@2.41.5",
+            "UID": "fba7380bbafc3c4f"
+          },
+          "Version": "2.41.5",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pydantic_core-2.41.5.dist-info/METADATA"
+        },
+        {
+          "Name": "pydantic_core",
+          "Identifier": {
+            "PURL": "pkg:pypi/pydantic-core@2.41.5",
+            "UID": "dcfdc808fb9f39e8"
+          },
+          "Version": "2.41.5",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pydantic_core-2.41.5.dist-info/METADATA"
+        },
+        {
+          "Name": "pyflakes",
+          "Identifier": {
+            "PURL": "pkg:pypi/pyflakes@3.4.0",
+            "UID": "2b9eed2ab0d14203"
+          },
+          "Version": "3.4.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pyflakes-3.4.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pyflakes",
+          "Identifier": {
+            "PURL": "pkg:pypi/pyflakes@3.4.0",
+            "UID": "3784b759051dc525"
+          },
+          "Version": "3.4.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pyflakes-3.4.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pytest",
+          "Identifier": {
+            "PURL": "pkg:pypi/pytest@8.4.2",
+            "UID": "370e176dd79e688f"
+          },
+          "Version": "8.4.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pytest-8.4.2.dist-info/METADATA"
+        },
+        {
+          "Name": "pytest",
+          "Identifier": {
+            "PURL": "pkg:pypi/pytest@9.0.2",
+            "UID": "4a2ac30ee9b679c2"
+          },
+          "Version": "9.0.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pytest-9.0.2.dist-info/METADATA"
+        },
+        {
+          "Name": "pytest-cov",
+          "Identifier": {
+            "PURL": "pkg:pypi/pytest-cov@7.0.0",
+            "UID": "d4683d8a444e4291"
+          },
+          "Version": "7.0.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/pytest_cov-7.0.0.dist-info/METADATA"
+        },
+        {
+          "Name": "pytest-cov",
+          "Identifier": {
+            "PURL": "pkg:pypi/pytest-cov@7.0.0",
+            "UID": "c28fec40180b845b"
+          },
+          "Version": "7.0.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/pytest_cov-7.0.0.dist-info/METADATA"
+        },
+        {
+          "Name": "ruff",
+          "Identifier": {
+            "PURL": "pkg:pypi/ruff@0.14.8",
+            "UID": "347a09b20047af95"
+          },
+          "Version": "0.14.8",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/ruff-0.14.8.dist-info/METADATA"
+        },
+        {
+          "Name": "ruff",
+          "Identifier": {
+            "PURL": "pkg:pypi/ruff@0.14.8",
+            "UID": "fffa7f91d6f379b1"
+          },
+          "Version": "0.14.8",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/ruff-0.14.8.dist-info/METADATA"
+        },
+        {
+          "Name": "setuptools",
+          "Identifier": {
+            "PURL": "pkg:pypi/setuptools@79.0.1",
+            "UID": "47bc65f64915a792"
+          },
+          "Version": "79.0.1",
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools-79.0.1.dist-info/METADATA"
+        },
+        {
+          "Name": "starlette",
+          "Identifier": {
+            "PURL": "pkg:pypi/starlette@0.49.3",
+            "UID": "c38ec18fe2f9322a"
+          },
+          "Version": "0.49.3",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/starlette-0.49.3.dist-info/METADATA"
+        },
+        {
+          "Name": "starlette",
+          "Identifier": {
+            "PURL": "pkg:pypi/starlette@0.50.0",
+            "UID": "eb9fc591c8476bf5"
+          },
+          "Version": "0.50.0",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/starlette-0.50.0.dist-info/METADATA"
+        },
+        {
+          "Name": "tomli",
+          "Identifier": {
+            "PURL": "pkg:pypi/tomli@2.0.1",
+            "UID": "bd293df389cd1198"
+          },
+          "Version": "2.0.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/tomli-2.0.1.dist-info/METADATA"
+        },
+        {
+          "Name": "tomli",
+          "Identifier": {
+            "PURL": "pkg:pypi/tomli@2.3.0",
+            "UID": "b61b883ab7b61e8e"
+          },
+          "Version": "2.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/tomli-2.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "typeguard",
+          "Identifier": {
+            "PURL": "pkg:pypi/typeguard@4.3.0",
+            "UID": "a588cf6f283f468d"
+          },
+          "Version": "4.3.0",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/typeguard-4.3.0.dist-info/METADATA"
+        },
+        {
+          "Name": "typing-inspection",
+          "Identifier": {
+            "PURL": "pkg:pypi/typing-inspection@0.4.2",
+            "UID": "101db2c776b42f66"
+          },
+          "Version": "0.4.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/typing_inspection-0.4.2.dist-info/METADATA"
+        },
+        {
+          "Name": "typing-inspection",
+          "Identifier": {
+            "PURL": "pkg:pypi/typing-inspection@0.4.2",
+            "UID": "b3ea382d28abc79d"
+          },
+          "Version": "0.4.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/typing_inspection-0.4.2.dist-info/METADATA"
+        },
+        {
+          "Name": "typing_extensions",
+          "Identifier": {
+            "PURL": "pkg:pypi/typing-extensions@4.12.2",
+            "UID": "45f2b20804d91c63"
+          },
+          "Version": "4.12.2",
+          "Licenses": [
+            "Python Software Foundation License"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/typing_extensions-4.12.2.dist-info/METADATA"
+        },
+        {
+          "Name": "typing_extensions",
+          "Identifier": {
+            "PURL": "pkg:pypi/typing-extensions@4.15.0",
+            "UID": "73349c1b07fa3bac"
+          },
+          "Version": "4.15.0",
+          "Licenses": [
+            "PSF-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/typing_extensions-4.15.0.dist-info/METADATA"
+        },
+        {
+          "Name": "typing_extensions",
+          "Identifier": {
+            "PURL": "pkg:pypi/typing-extensions@4.15.0",
+            "UID": "eb9e9e23f4c16cec"
+          },
+          "Version": "4.15.0",
+          "Licenses": [
+            "PSF-2.0"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/typing_extensions-4.15.0.dist-info/METADATA"
+        },
+        {
+          "Name": "uvicorn",
+          "Identifier": {
+            "PURL": "pkg:pypi/uvicorn@0.38.0",
+            "UID": "7c354327b513ec9a"
+          },
+          "Version": "0.38.0",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "FilePath": "app/pc5/lib/python3.12/site-packages/uvicorn-0.38.0.dist-info/METADATA"
+        },
+        {
+          "Name": "uvicorn",
+          "Identifier": {
+            "PURL": "pkg:pypi/uvicorn@0.38.0",
+            "UID": "3cff447bbeec0fcf"
+          },
+          "Version": "0.38.0",
+          "Licenses": [
+            "BSD-3-Clause"
+          ],
+          "Layer": {
+            "DiffID": "sha256:c5519e45b2b9c56951b862d8c37ec0cea330a231656cc225e8584d028f3b9ffb"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/uvicorn-0.38.0.dist-info/METADATA"
+        },
+        {
+          "Name": "wheel",
+          "Identifier": {
+            "PURL": "pkg:pypi/wheel@0.45.1",
+            "UID": "26f57dcc0ec47cc1"
+          },
+          "Version": "0.45.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/wheel-0.45.1.dist-info/METADATA"
+        },
+        {
+          "Name": "wheel",
+          "Identifier": {
+            "PURL": "pkg:pypi/wheel@0.45.1",
+            "UID": "9b0e806fb26e65ba"
+          },
+          "Version": "0.45.1",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/wheel-0.45.1.dist-info/METADATA"
+        },
+        {
+          "Name": "zipp",
+          "Identifier": {
+            "PURL": "pkg:pypi/zipp@3.19.2",
+            "UID": "c0e6c1ba88b4d235"
+          },
+          "Version": "3.19.2",
+          "Licenses": [
+            "MIT"
+          ],
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "FilePath": "usr/local/lib/python3.9/site-packages/setuptools/_vendor/zipp-3.19.2.dist-info/METADATA"
+        }
+      ],
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2023-5752",
+          "PkgName": "pip",
+          "PkgPath": "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
+          "PkgIdentifier": {
+            "PURL": "pkg:pypi/pip@23.0.1",
+            "UID": "db4b2871e1f85d98"
+          },
+          "InstalledVersion": "23.0.1",
+          "FixedVersion": "23.3",
+          "Status": "fixed",
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "SeveritySource": "ghsa",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-5752",
+          "DataSource": {
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory pip",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apip"
+          },
+          "Fingerprint": "sha256:3f715376feca9d523c8d40b1a99e49e274aec59a4d366590df440df35f66fedc",
+          "Title": "pip: Mercurial configuration injectable in repo revision when installing via pip",
+          "Description": "When installing a package from a Mercurial VCS URL  (ie \"pip install \nhg+...\") with pip prior to v23.3, the specified Mercurial revision could\n be used to inject arbitrary configuration options to the \"hg clone\" \ncall (ie \"--config\"). Controlling the Mercurial configuration can modify\n how and which repository is installed. This vulnerability does not \naffect users who aren't installing from Mercurial.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-77"
+          ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "azure": 1,
+            "bitnami": 1,
+            "cbl-mariner": 2,
+            "ghsa": 2,
+            "nvd": 1,
+            "redhat": 1
+          },
+          "CVSS": {
+            "bitnami": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 3.3
+            },
+            "ghsa": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+              "V3Score": 5.5
+            },
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 3.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+              "V3Score": 3.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2023-5752",
+            "https://github.com/pypa/advisory-database/tree/main/vulns/pip/PYSEC-2023-228.yaml",
+            "https://github.com/pypa/pip",
+            "https://github.com/pypa/pip/commit/389cb799d0da9a840749fcd14878928467ed49b4",
+            "https://github.com/pypa/pip/pull/12306",
+            "https://lists.debian.org/debian-lts-announce/2025/10/msg00028.html",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/622OZXWG72ISQPLM5Y57YCVIMWHD4C3U",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/622OZXWG72ISQPLM5Y57YCVIMWHD4C3U/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/65UKKF5LBHEFDCUSPBHUN4IHYX7SRMHH",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/65UKKF5LBHEFDCUSPBHUN4IHYX7SRMHH/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FXUVMJM25PUAZRQZBF54OFVKTY3MINPW",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FXUVMJM25PUAZRQZBF54OFVKTY3MINPW/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KFC2SPFG5FLCZBYY2K3T5MFW2D22NG6E",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KFC2SPFG5FLCZBYY2K3T5MFW2D22NG6E/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YBSB3SUPQ3VIFYUMHPO3MEQI4BJAXKCZ",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YBSB3SUPQ3VIFYUMHPO3MEQI4BJAXKCZ/",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/F4PL35U6X4VVHZ5ILJU3PWUWN7H7LZXL",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/F4PL35U6X4VVHZ5ILJU3PWUWN7H7LZXL/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2023-5752",
+            "https://www.cve.org/CVERecord?id=CVE-2023-5752"
+          ],
+          "PublishedDate": "2023-10-25T18:17:44.867Z",
+          "LastModifiedDate": "2025-11-03T18:15:41.173Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-8869",
+          "PkgName": "pip",
+          "PkgPath": "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
+          "PkgIdentifier": {
+            "PURL": "pkg:pypi/pip@23.0.1",
+            "UID": "db4b2871e1f85d98"
+          },
+          "InstalledVersion": "23.0.1",
+          "FixedVersion": "25.3",
+          "Status": "fixed",
+          "Layer": {
+            "DiffID": "sha256:298992e09a0315a8f26375a553f216f5fad3decf392956fd2de5ef7aa1f8dfea"
+          },
+          "SeveritySource": "ghsa",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-8869",
+          "DataSource": {
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory pip",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apip"
+          },
+          "Fingerprint": "sha256:f619874a7a5d59ffa8498e9c0ffc21f2d0b45ae3fa0e9b9277bbad6e183c855d",
+          "Title": "pip: pip missing checks on symbolic link extraction",
+          "Description": "When extracting a tar archive pip may not check symbolic links point into the extraction directory if the tarfile module doesn't implement PEP 706.\nNote that upgrading pip to a \"fixed\" version for this vulnerability doesn't fix all known vulnerabilities that are remediated by using a Python version that implements PEP 706.\n\nNote that this is a vulnerability in pip's fallback implementation of tar extraction for Python versions that don't implement PEP 706\nand therefore are not secure to all vulnerabilities in the Python 'tarfile' module. If you're using a Python version that implements PEP 706\nthen pip doesn't use the \"vulnerable\" fallback code.\n\nMitigations include upgrading to a version of pip that includes the fix, upgrading to a Python version that implements PEP 706 (Python \u003e=3.9.17, \u003e=3.10.12, \u003e=3.11.4, or \u003e=3.12),\napplying the linked patch, or inspecting source distributions (sdists) before installation as is already a best-practice.",
+          "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "amazon": 2,
+            "azure": 2,
+            "ghsa": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-8869",
+            "https://github.com/pypa/pip",
+            "https://github.com/pypa/pip/commit/f2b92314da012b9fffa36b3f3e67748a37ef464a",
+            "https://github.com/pypa/pip/pull/13550",
+            "https://lists.debian.org/debian-lts-announce/2025/10/msg00028.html",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/IF5A3GCJY3VH7BVHJKOWOJFKTW7VFQEN",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/IF5A3GCJY3VH7BVHJKOWOJFKTW7VFQEN/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-8869",
+            "https://pip.pypa.io/en/stable/news/#v25-2",
+            "https://www.cve.org/CVERecord?id=CVE-2025-8869"
+          ],
+          "PublishedDate": "2025-09-24T15:15:41.293Z",
+          "LastModifiedDate": "2025-11-03T18:17:02.783Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2025-8869",
+          "PkgName": "pip",
+          "PkgPath": "app/pc5/lib/python3.12/site-packages/pip-24.0.dist-info/METADATA",
+          "PkgIdentifier": {
+            "PURL": "pkg:pypi/pip@24.0",
+            "UID": "cc9459dfee37b119"
+          },
+          "InstalledVersion": "24.0",
+          "FixedVersion": "25.3",
+          "Status": "fixed",
+          "Layer": {
+            "DiffID": "sha256:80f472485415e64d6f63030e55e23d47d5cac3b466f83bc653503aa6965ae5aa"
+          },
+          "SeveritySource": "ghsa",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-8869",
+          "DataSource": {
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory pip",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apip"
+          },
+          "Fingerprint": "sha256:f619874a7a5d59ffa8498e9c0ffc21f2d0b45ae3fa0e9b9277bbad6e183c855d",
+          "Title": "pip: pip missing checks on symbolic link extraction",
+          "Description": "When extracting a tar archive pip may not check symbolic links point into the extraction directory if the tarfile module doesn't implement PEP 706.\nNote that upgrading pip to a \"fixed\" version for this vulnerability doesn't fix all known vulnerabilities that are remediated by using a Python version that implements PEP 706.\n\nNote that this is a vulnerability in pip's fallback implementation of tar extraction for Python versions that don't implement PEP 706\nand therefore are not secure to all vulnerabilities in the Python 'tarfile' module. If you're using a Python version that implements PEP 706\nthen pip doesn't use the \"vulnerable\" fallback code.\n\nMitigations include upgrading to a version of pip that includes the fix, upgrading to a Python version that implements PEP 706 (Python \u003e=3.9.17, \u003e=3.10.12, \u003e=3.11.4, or \u003e=3.12),\napplying the linked patch, or inspecting source distributions (sdists) before installation as is already a best-practice.",
+          "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "amazon": 2,
+            "azure": 2,
+            "ghsa": 2,
+            "redhat": 2
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2025-8869",
+            "https://github.com/pypa/pip",
+            "https://github.com/pypa/pip/commit/f2b92314da012b9fffa36b3f3e67748a37ef464a",
+            "https://github.com/pypa/pip/pull/13550",
+            "https://lists.debian.org/debian-lts-announce/2025/10/msg00028.html",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/IF5A3GCJY3VH7BVHJKOWOJFKTW7VFQEN",
+            "https://mail.python.org/archives/list/security-announce@python.org/thread/IF5A3GCJY3VH7BVHJKOWOJFKTW7VFQEN/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-8869",
+            "https://pip.pypa.io/en/stable/news/#v25-2",
+            "https://www.cve.org/CVERecord?id=CVE-2025-8869"
+          ],
+          "PublishedDate": "2025-09-24T15:15:41.293Z",
+          "LastModifiedDate": "2025-11-03T18:17:02.783Z"
+        }
+      ]
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Variables de entorno
-
+EVIDENCE_DIR = .evidence
+IMAGE_NAME = myapp:latest
 # Flags comunes para pytest (puedes ampliarlas)
 PYTEST_FLAGS ?= -q -v
 PY_WARNINGS  ?= ignore::DeprecationWarning
@@ -69,3 +70,19 @@ clean: ## Elimina archivos temporales, caches, etc.
 	# ruff
 	rm -rf .ruff_cache 2>/dev/null || true
 	@echo "Limpieza completa."
+
+.PHONY: coverage_reporte
+coverage_reporte: 
+	@mkdir -p $(EVIDENCE_DIR)
+	@echo "Ejecutando cobertura..."
+	PYTHONWARNINGS="$(PY_WARNINGS)" pytest --cov=app --cov-report=term-missing > $(EVIDENCE_DIR)/ci-report.txt
+	@echo "Reporte de cobertura guardado en $(EVIDENCE_DIR)/ci-report.txt"
+
+.PHONY: evidence
+evidence: coverage_reporte lint ## Genera SBOM (Syft) y Escaneo (Trivy)
+	@mkdir -p $(EVIDENCE_DIR)
+	@echo "Generando SBOM con Syft..."
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(PWD)/$(EVIDENCE_DIR):/evidence anchore/syft $(IMAGE_NAME) -o json > $(EVIDENCE_DIR)/sbom.json
+	@echo "Ejecutando escaneo con Trivy..."
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(PWD)/$(EVIDENCE_DIR):/evidence ghcr.io/aquasecurity/trivy:latest image --format json --output /evidence/trivy-report.json $(IMAGE_NAME)
+	@echo "Evidencias completadas en $(EVIDENCE_DIR)/"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,8 @@
 import os
-
+from unittest.mock import MagicMock, patch
+import app.main as main_module
 
 os.environ["USE_MEMORY_DB"] = "true"
-
 
 from fastapi.testclient import TestClient
 from app.main import app, get_db
@@ -59,3 +59,49 @@ def test_obtener_nota_inexistente():
     response = client.get("/notes/9999")
     assert response.status_code == 404
     assert response.json()["detail"] == "Note not found"
+
+
+def test_salud_db_con_error(monkeypatch):
+    monkeypatch.setattr(main_module, "USE_MEMORY_DB", False)
+    
+    with patch("app.main.get_db") as mock_get_db:
+        mock_db_session = MagicMock()
+        mock_db_session.execute.side_effect = Exception("DB Error")
+        mock_get_db.return_value = iter([mock_db_session])
+        
+        original_overrides = app.dependency_overrides.copy()
+        app.dependency_overrides = {}
+        
+        response = client.get("/health")
+        
+        app.dependency_overrides = original_overrides
+        
+        assert response.status_code == 200
+        assert response.json()["database"] == "memory"
+
+
+def test_logica_db():
+    with patch("app.database.SessionLocal") as mock_session_local:
+        mock_session = MagicMock()
+        mock_session_local.return_value = mock_session
+
+        generator = get_db()
+        db_instance = next(generator)
+        
+        assert db_instance == mock_session
+        generator.close() 
+        mock_session.close.assert_called_once()
+
+def test_crear_nota_postgres_excepcion(monkeypatch):
+    monkeypatch.setattr(main_module, "USE_MEMORY_DB", False)
+    with patch("app.main.get_db") as mock_get_db:
+        mock_session = MagicMock()
+        mock_session.add.side_effect = Exception("Commit Fail")
+        mock_get_db.return_value = iter([mock_session])
+        
+        orig = app.dependency_overrides.copy()
+        app.dependency_overrides = {}
+        response = client.post("/notes", json={"title": "Err", "content": "Err"})
+        app.dependency_overrides = orig
+        
+        assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,16 @@
 import os
 
-import pytest
-from fastapi.testclient import TestClient
-
-from app.main import app
 
 os.environ["USE_MEMORY_DB"] = "true"
 
+
+from fastapi.testclient import TestClient
+from app.main import app, get_db
+
+def override_get_db():
+    yield None
+
+app.dependency_overrides[get_db] = override_get_db
 client = TestClient(app)
 
 
@@ -50,7 +54,6 @@ def test_obtener_nota_por_id():
     assert nota["content"] == "Contenido Especifico"
 
 
-@pytest.mark.xfail(reason="Conexion a DB deshabilitada")
 def test_obtener_nota_inexistente():
     # Intentar obtener una nota que no existe
     response = client.get("/notes/9999")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,17 @@
 import os
 from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
 import app.main as main_module
+from app.main import app, get_db
 
 os.environ["USE_MEMORY_DB"] = "true"
 
-from fastapi.testclient import TestClient
-from app.main import app, get_db
 
 def override_get_db():
     yield None
+
 
 app.dependency_overrides[get_db] = override_get_db
 client = TestClient(app)
@@ -63,19 +66,19 @@ def test_obtener_nota_inexistente():
 
 def test_salud_db_con_error(monkeypatch):
     monkeypatch.setattr(main_module, "USE_MEMORY_DB", False)
-    
+
     with patch("app.main.get_db") as mock_get_db:
         mock_db_session = MagicMock()
         mock_db_session.execute.side_effect = Exception("DB Error")
         mock_get_db.return_value = iter([mock_db_session])
-        
+
         original_overrides = app.dependency_overrides.copy()
         app.dependency_overrides = {}
-        
+
         response = client.get("/health")
-        
+
         app.dependency_overrides = original_overrides
-        
+
         assert response.status_code == 200
         assert response.json()["database"] == "memory"
 
@@ -87,10 +90,11 @@ def test_logica_db():
 
         generator = get_db()
         db_instance = next(generator)
-        
+
         assert db_instance == mock_session
-        generator.close() 
+        generator.close()
         mock_session.close.assert_called_once()
+
 
 def test_crear_nota_postgres_excepcion(monkeypatch):
     monkeypatch.setattr(main_module, "USE_MEMORY_DB", False)
@@ -98,10 +102,10 @@ def test_crear_nota_postgres_excepcion(monkeypatch):
         mock_session = MagicMock()
         mock_session.add.side_effect = Exception("Commit Fail")
         mock_get_db.return_value = iter([mock_session])
-        
+
         orig = app.dependency_overrides.copy()
         app.dependency_overrides = {}
         response = client.post("/notes", json={"title": "Err", "content": "Err"})
         app.dependency_overrides = orig
-        
+
         assert response.status_code == 200


### PR DESCRIPTION
Este PR agrega la automatizacion de tareas para generar evidencias DevSecOps. Se incluyen nuevos targets en el Makefile para  generar reportes con Syft y Trivy.

## Cambios principales
- Nuevo target `evidence` para generar `sbom.json` y `trivy-report.json`.
- Creacion automatica del directorio `.evidence`.

## Checklist
- [x] `sbom.json` generado por Syft.
- [x] `trivy-report.json` generado por Trivy.
- [x] `coverage_reporte` funciona correctamente.

cumple con el issue #18
