### PR TITLE
Deployment y Service para notes-app

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: notes
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 2000
       containers:
       - name: notes-api
         image: myapp:latest
@@ -25,3 +29,15 @@ spec:
             name: notes-config
         - secretRef:
             name: notes-secret
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+      volumes:
+      - name: tmp-volume
+        emptyDir: {}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notes-app
+  labels:
+    app: notes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notes
+  template:
+    metadata:
+      labels:
+        app: notes
+    spec:
+      containers:
+      - name: notes-api
+        image: myapp:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+        envFrom:
+        - configMapRef:
+            name: notes-config
+        - secretRef:
+            name: notes-secret

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notes-service
+spec:
+  selector:
+    app: notes
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: NodePort


### PR DESCRIPTION
Este pullrerquest es para implementar los manifiestos de Deployment y Service que permitiran el despliegue de la aplicacion en Kubernetes.

Incluyen:
- [x] Deployment con 1 replica usando la imagen myapp:latest.
- [x] Exposicion de la app mediante Service tipo NodePort. 
- [x] Mapeo del puerto 8000 (contenedor) -> 80 (cluster). 
- [x] Endurecimiento de seguridad del contenedor (usuario no-root, FS de solo lectura, capabilities deshabilitadas).

Cumpliendo asi con los criterios de aceptacion del issue #21 .